### PR TITLE
Add Next.js frontend + BM-093 preview validation

### DIFF
--- a/backend/app/api/v1/endpoints/orders.py
+++ b/backend/app/api/v1/endpoints/orders.py
@@ -13,6 +13,7 @@ from uuid import UUID
 
 from sqlmodel import Session
 import stripe  # For webhook verification if not done by a library
+from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from app.repositories.sqlite_adapter import get_session
 from app.services.order_service import OrderService, QuoteService
@@ -38,6 +39,33 @@ from app.auth.dependencies import get_current_active_user
 from app.core.config import settings
 
 router = APIRouter()
+
+
+def _raise_local_dev_readiness_error(exc: Exception) -> None:
+    detail = str(exc)
+    if "no such column" not in detail.lower():
+        raise exc
+
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail={
+            "code": "local_dev_schema_stale",
+            "message": "Local dev data needs a schema refresh before Ops Home can load live queue data.",
+            "title": "Local dev setup needs refresh",
+            "note": "This is a local BakeMate setup issue, not a bakery workflow status.",
+            "action": "Refresh or reseed the local dev database, then reload /ops.",
+            "recovery_command_label": "Run locally from the BakeMate repo",
+            "recovery_command": "docker compose up --build -d",
+            "guidance_title": "How to recover locally",
+            "guidance_source": "README.md and docs/developer_guide.md",
+            "guidance_steps": [
+                "Use the normal BakeMate local setup flow from README.md or docs/developer_guide.md to refresh the local dev environment.",
+                "If your local BakeMate database was recreated, repopulate it using your usual local seed path before reloading /ops.",
+                "Reload /ops after the local dev database is refreshed.",
+            ],
+            "raw_error": detail,
+        },
+    )
 
 # --- Order Endpoints --- #
 
@@ -75,19 +103,22 @@ async def read_orders(
     current_user: User = Depends(get_current_active_user),
 ):
     order_service = OrderService(session=session)
-    orders = await order_service.get_orders_by_user(
-        current_user=current_user,
-        skip=skip,
-        limit=limit,
-        status=status_filter,
-        imported_only=imported_only,
-        search=search,
-        needs_review=needs_review,
-        review_reason=review_reason,
-        day_running=day_running,
-        action_class=action_class,
-        urgency=urgency,
-    )
+    try:
+        orders = await order_service.get_orders_by_user(
+            current_user=current_user,
+            skip=skip,
+            limit=limit,
+            status=status_filter,
+            imported_only=imported_only,
+            search=search,
+            needs_review=needs_review,
+            review_reason=review_reason,
+            day_running=day_running,
+            action_class=action_class,
+            urgency=urgency,
+        )
+    except (OperationalError, ProgrammingError) as exc:
+        _raise_local_dev_readiness_error(exc)
     return orders
 
 
@@ -105,16 +136,19 @@ async def read_day_running_queue_summary(
     current_user: User = Depends(get_current_active_user),
 ):
     order_service = OrderService(session=session)
-    return await order_service.get_day_running_queue_summary(
-        current_user=current_user,
-        status=status_filter,
-        imported_only=imported_only,
-        search=search,
-        needs_review=needs_review,
-        review_reason=review_reason,
-        action_class=action_class,
-        urgency=urgency,
-    )
+    try:
+        return await order_service.get_day_running_queue_summary(
+            current_user=current_user,
+            status=status_filter,
+            imported_only=imported_only,
+            search=search,
+            needs_review=needs_review,
+            review_reason=review_reason,
+            action_class=action_class,
+            urgency=urgency,
+        )
+    except (OperationalError, ProgrammingError) as exc:
+        _raise_local_dev_readiness_error(exc)
 
 
 @router.get("/imported/summary", response_model=ImportedOrderQueueSummary)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -10,6 +10,10 @@ from dotenv import load_dotenv
 load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), "..", "..", ".env"))
 
 
+def _split_env_list(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
 class Settings(BaseSettings):
     # API settings
     API_V1_STR: str = "/api/v1"
@@ -51,7 +55,14 @@ class Settings(BaseSettings):
     # SECURE_COOKIE_NAME: str = "bakemate_auth"
 
     # CORS (Cross-Origin Resource Sharing)
-    # BACKEND_CORS_ORIGINS: list[str] = os.getenv("BACKEND_CORS_ORIGINS", "http://localhost:3000,http://localhost:5173").split(',')
+    BACKEND_CORS_ORIGINS: str = os.getenv(
+        "BACKEND_CORS_ORIGINS",
+        "http://localhost:5173,http://127.0.0.1:5173",
+    )
+
+    @property
+    def backend_cors_origins(self) -> list[str]:
+        return _split_env_list(self.BACKEND_CORS_ORIGINS)
 
     # Default user settings (example)
     # DEFAULT_USER_HOURLY_RATE: float = 25.0

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -205,6 +205,11 @@ class OrderPaymentFocusSummary(SQLModel):
     risk_note: str
     next_step: str
     next_step_detail: str
+    trust_state: str = "current"
+    trust_label: str = "Current BakeMate payment context"
+    trust_note: str = "Payment status comes from current BakeMate order data."
+    historical_payment_label: Optional[str] = None
+    historical_payment_note: Optional[str] = None
 
 
 class OrderHandoffFocusSummary(SQLModel):
@@ -232,6 +237,7 @@ class OrderReviewFocusSummary(SQLModel):
     payment_confidence: str
     invoice_confidence: str
     handoff_confidence: str
+    payment_trust_preview: Optional[str] = None
     missing_basics: List[str] = []
     risk_note: str
     next_step: str
@@ -265,6 +271,7 @@ class OrderDayRunningFocusSummary(SQLModel):
     primary_blocker_label: str
     queue_reason_preview: Optional[str] = None
     queue_next_step_preview: Optional[str] = None
+    queue_payment_trust_preview: Optional[str] = None
     queue_contact_preview: Optional[str] = None
     queue_payment_preview: Optional[str] = None
     queue_handoff_preview: Optional[str] = None

--- a/backend/app/services/order_service.py
+++ b/backend/app/services/order_service.py
@@ -1064,6 +1064,8 @@ class OrderService:
         queue_summary: OrderQueueSummary,
         risk_summary: OrderRiskSummary,
         ops_summary: OrderOpsSummary,
+        *,
+        is_imported: bool,
     ) -> OrderPaymentFocusSummary:
         today = _utcnow().date()
         balance_due_amount = round(max(payment_summary.amount_due - payment_summary.deposit_outstanding, 0.0), 2)
@@ -1154,6 +1156,23 @@ class OrderService:
         else:
             amount_owed_now = payment_summary.amount_due
 
+        trust_state = "current"
+        trust_label = "Current BakeMate payment context"
+        trust_note = "Payment status comes from current BakeMate order data."
+        historical_payment_label: Optional[str] = None
+        historical_payment_note: Optional[str] = None
+        if is_imported:
+            trust_state = "legacy_limited"
+            trust_label = "Imported payment history is legacy-limited"
+            trust_note = (
+                "This order was imported from legacy data, so BakeMate is showing a conservative payment snapshot "
+                "instead of a reconstructed payment ledger. Treat historical payment history as unknown unless you have a second source."
+            )
+            historical_payment_label = "Historical payment: unknown"
+            historical_payment_note = (
+                "Legacy payment history may be incomplete in this import. Use a second source before treating earlier payments as confirmed."
+            )
+
         return OrderPaymentFocusSummary(
             amount_owed_now=round(amount_owed_now, 2),
             payment_state=payment_state,
@@ -1164,6 +1183,11 @@ class OrderService:
             risk_note=risk_note,
             next_step=ops_summary.next_action,
             next_step_detail=ops_summary.ops_attention,
+            trust_state=trust_state,
+            trust_label=trust_label,
+            trust_note=trust_note,
+            historical_payment_label=historical_payment_label,
+            historical_payment_note=historical_payment_note,
         )
 
     def _build_handoff_focus_summary(
@@ -1471,8 +1495,8 @@ class OrderService:
             "Confirm pickup handoff details": "Confirm pickup handoff",
             "Lock the handoff basics": "Lock handoff basics",
             "Lock the handoff basics first": "Lock handoff basics",
-            "Lock the missing production basics": "Lock bake details",
-            "Confirm production details": "Confirm bake details",
+            "Lock the missing production basics": "Lock production basics",
+            "Confirm production details": "Confirm production basics",
             "Proceed with production prep": "Start production prep",
             "Use the saved contact details": "Use contact info",
             "Add an email backup if you talk to the customer": "Add email backup",
@@ -1483,17 +1507,17 @@ class OrderService:
             "Add an email backup": "Add email backup",
             "Review deposit follow-up": "Review deposit",
             "Collect the overdue deposit": "Collect deposit",
-            "Collect the overdue balance": "Collect balance",
-            "Review final balance collection": "Review balance collection",
+            "Collect the overdue balance": "Collect final balance",
+            "Review final balance collection": "Review final balance",
             "Proceed with today’s order plan": "Proceed with order plan",
             "Recheck timing and proceed": "Recheck timing",
             "Keep the order on track": "Keep on track",
         }.get(next_step, next_step)
 
-        if normalized_reason == "production details need clarification" and compact_next_step == "Confirm bake details":
-            compact_next_step = "Clarify bake details"
-        elif normalized_reason.startswith("production details are thin") and compact_next_step == "Confirm bake details":
-            compact_next_step = "Clarify bake details"
+        if normalized_reason == "production details need clarification" and compact_next_step == "Confirm production basics":
+            compact_next_step = "Clarify production basics"
+        elif normalized_reason.startswith("production details are thin") and compact_next_step == "Confirm production basics":
+            compact_next_step = "Clarify production basics"
         elif normalized_reason == "invoice is still missing basics for today" and compact_next_step in {"Finish invoice", "Complete invoice details"}:
             compact_next_step = "Finish invoice"
 
@@ -1503,19 +1527,19 @@ class OrderService:
         normalized_reason = reason_summary.strip().rstrip(".")
 
         if normalized_reason.startswith("Deposit is still open "):
-            compact_reason = "Deposit still open"
+            compact_reason = "Deposit due"
         elif normalized_reason.startswith("Deposit is still unpaid "):
-            compact_reason = "Deposit overdue"
+            compact_reason = "Overdue deposit"
         elif normalized_reason.startswith("Final balance is overdue "):
-            compact_reason = "Final balance overdue"
+            compact_reason = "Overdue final balance"
         elif normalized_reason.startswith("Final balance is still open "):
-            compact_reason = "Final balance still open"
+            compact_reason = "Final balance due"
         else:
             compact_reason = {
                 "Confirm pickup vs delivery so today’s release plan is clear": "Handoff method not confirmed",
-                "Invoice is still missing basics for today": "Invoice details missing",
-                "production basics missing": "Bake details missing",
-                "production details need clarification": "Bake details need clarification",
+                "Invoice is still missing basics for today": "Invoice basics missing",
+                "production basics missing": "Production basics missing",
+                "production details need clarification": "Production basics need clarification",
                 "contact basics missing": "Contact info missing",
                 "contact fallback is thin": "Backup contact info missing",
                 "handoff basics missing": "Handoff basics missing",
@@ -1523,6 +1547,16 @@ class OrderService:
 
         prefix = "Blocked" if readiness_label == "Blocked for today" else "Attention"
         return f"{prefix}: {compact_reason}"
+
+    def _build_queue_payment_trust_preview(self, *, payment_focus_summary: OrderPaymentFocusSummary) -> Optional[str]:
+        if payment_focus_summary.trust_state != "legacy_limited":
+            return None
+        return "Payment trust: legacy-limited"
+
+    def _build_review_payment_trust_preview(self, *, payment_focus_summary: OrderPaymentFocusSummary) -> Optional[str]:
+        if payment_focus_summary.trust_state != "legacy_limited":
+            return None
+        return "Payment trust: legacy-limited"
 
     def _build_day_running_contact_preview(
         self,
@@ -1593,10 +1627,14 @@ class OrderService:
         if payment_focus_summary.collection_stage == "deposit":
             return f"Collect: ${payment_focus_summary.amount_owed_now:.2f} deposit"
         if payment_focus_summary.collection_stage == "balance":
-            return f"Collect: ${payment_focus_summary.amount_owed_now:.2f} balance"
+            return f"Collect: ${payment_focus_summary.amount_owed_now:.2f} final balance"
         if payment_focus_summary.collection_stage == "settled":
-            return "Payment: fully paid"
-        return "Payment: amount needs review"
+            return "Paid in full"
+        if next_step == "Review deposit follow-up":
+            return "Deposit review needed"
+        if next_step == "Review final balance collection":
+            return "Final balance review needed"
+        return "Payment review needed"
 
     def _build_day_running_production_preview(
         self,
@@ -1660,7 +1698,7 @@ class OrderService:
             return None
 
         invoice_related_next_steps = {
-            "Complete invoice details",
+            "Complete invoice basics",
             "Complete invoice basics",
             "Send invoice with deposit guidance",
             "Confirm final payment timing",
@@ -1856,7 +1894,7 @@ class OrderService:
                 (
                     "invoice",
                     "Invoice is still missing basics for today.",
-                    "Complete invoice details",
+                    "Complete invoice basics",
                     invoice_summary.missing_fields[0].replace("_", " ") if invoice_summary.missing_fields else "invoice basics missing",
                 )
             )
@@ -2026,6 +2064,9 @@ class OrderService:
             queue_reason_preview = None
             queue_next_step_preview = None
 
+        queue_payment_trust_preview = self._build_queue_payment_trust_preview(
+            payment_focus_summary=payment_focus_summary,
+        )
         queue_contact_preview = self._build_day_running_contact_preview(
             readiness_label=readiness_label,
             primary_category=primary_category,
@@ -2075,6 +2116,7 @@ class OrderService:
             primary_blocker_label=_humanize_enum_label(primary_label),
             queue_reason_preview=queue_reason_preview,
             queue_next_step_preview=queue_next_step_preview,
+            queue_payment_trust_preview=queue_payment_trust_preview,
             queue_contact_preview=queue_contact_preview,
             queue_payment_preview=queue_payment_preview,
             queue_handoff_preview=queue_handoff_preview,
@@ -2094,6 +2136,7 @@ class OrderService:
         queue_summary: OrderQueueSummary,
         risk_summary: OrderRiskSummary,
         handoff_focus_summary: OrderHandoffFocusSummary,
+        payment_focus_summary: OrderPaymentFocusSummary,
         ops_summary: OrderOpsSummary,
     ) -> OrderReviewFocusSummary:
         customer_name = customer_summary.name or "Customer name still missing"
@@ -2161,6 +2204,9 @@ class OrderService:
             payment_confidence=payment_confidence,
             invoice_confidence=invoice_confidence,
             handoff_confidence=handoff_confidence,
+            payment_trust_preview=self._build_review_payment_trust_preview(
+                payment_focus_summary=payment_focus_summary,
+            ),
             missing_basics=missing_basics,
             risk_note=risk_note,
             next_step=ops_summary.next_action,
@@ -2201,7 +2247,7 @@ class OrderService:
         if not invoice_summary.is_ready:
             return build_summary(
                 action_class="invoice_blocked",
-                next_action="Complete invoice details",
+                next_action="Complete invoice basics",
                 ops_attention="Invoice blocked until missing fields are filled in.",
                 primary_cta_label="Finish invoice",
                 primary_cta_panel="invoice",
@@ -2338,14 +2384,15 @@ class OrderService:
             invoice_summary,
             risk_summary,
         )
+        is_imported, legacy_status_raw, import_source = self._derive_import_metadata(order)
         payment_focus_summary = self._build_payment_focus_summary(
             order,
             payment_summary,
             queue_summary,
             risk_summary,
             ops_summary,
+            is_imported=is_imported,
         )
-        is_imported, legacy_status_raw, import_source = self._derive_import_metadata(order)
         review_reasons, primary_review_reason, review_next_check = self._build_import_review_triage(
             is_imported=is_imported,
             customer_summary=customer_summary,
@@ -2366,6 +2413,7 @@ class OrderService:
             queue_summary,
             risk_summary,
             handoff_focus_summary,
+            payment_focus_summary,
             ops_summary,
         )
         production_focus_summary = self._build_production_focus_summary(

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,7 +29,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "https://5173-firebase-bakemate-1757558933053.cluster-fizdampoefe4ktb4qlhma6i3ck.cloudworkstations.dev"],
+    allow_origins=settings.backend_cors_origins,
     allow_credentials=True,
     allow_methods=["POST", "GET", "PUT", "DELETE"],
     allow_headers=["Content-Type", "Authorization"],

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,50 +1,118 @@
 import asyncio
-from sqlmodel import Session
+from datetime import date, datetime, timezone
 
+from sqlmodel import Session
+from sqlmodel import select
+
+from app.models.order import Order, OrderItem, OrderStatus, PaymentStatus
 from app.models.user import User, UserCreate
 from app.models.recipe import Recipe, RecipeCreate
 from app.services.user_service import UserService
 from app.repositories.sqlite_adapter import engine
 
+PREVIEW_VALIDATION_ORDER_NUMBER = "ORD-PREVIEW-VALIDATION"
+PREVIEW_VALIDATION_USER_EMAIL = "test@example.com"
+PREVIEW_VALIDATION_PASSWORD = "password"
+
+
+async def ensure_seed_user(
+    session: Session,
+    *,
+    email: str = PREVIEW_VALIDATION_USER_EMAIL,
+    password: str = PREVIEW_VALIDATION_PASSWORD,
+) -> User:
+    user_service = UserService(session)
+    user = await user_service.get_user_by_email(email)
+    if user:
+        return user
+    return await user_service.create_user(UserCreate(email=email, password=password))
+
+
+def ensure_seed_recipes(session: Session, *, user: User) -> None:
+    existing_recipe = session.exec(
+        select(Recipe).where(Recipe.user_id == user.id)
+    ).first()
+    if existing_recipe:
+        return
+
+    recipes_data = [
+        {
+            "name": "Classic Chocolate Chip Cookies",
+            "description": "The best chocolate chip cookies ever!",
+            "user_id": user.id,
+            "instructions": "1. Preheat oven. 2. Mix dough. 3. Bake until edges are browned.",
+        },
+        {
+            "name": "Sourdough Bread",
+            "description": "A crusty, chewy sourdough bread.",
+            "user_id": user.id,
+            "instructions": "1. Feed starter. 2. Mix dough. 3. Ferment, shape, and bake.",
+        },
+        {
+            "name": "New York-Style Pizza",
+            "description": "A classic New York-style pizza with a thin, crisp crust.",
+            "user_id": user.id,
+            "instructions": "1. Make dough. 2. Make sauce. 3. Assemble and bake.",
+        },
+    ]
+
+    for recipe_data in recipes_data:
+        recipe_in = RecipeCreate(**recipe_data)
+        session.add(Recipe(**recipe_in.model_dump(by_alias=False)))
+    session.commit()
+
+
+def ensure_preview_validation_order(session: Session, *, user: User) -> Order:
+    existing_order = session.exec(
+        select(Order).where(
+            Order.user_id == user.id,
+            Order.order_number == PREVIEW_VALIDATION_ORDER_NUMBER,
+        )
+    ).first()
+    if existing_order:
+        return existing_order
+
+    order = Order(
+        user_id=user.id,
+        order_number=PREVIEW_VALIDATION_ORDER_NUMBER,
+        customer_name="Preview Validation Customer",
+        customer_email="preview-validation@example.com",
+        customer_phone="555-0195",
+        status=OrderStatus.CONFIRMED,
+        payment_status=PaymentStatus.UNPAID,
+        order_date=datetime(2026, 4, 21, 12, 0, tzinfo=timezone.utc),
+        due_date=datetime(2026, 4, 22, 14, 0, tzinfo=timezone.utc),
+        delivery_method="Pickup",
+        subtotal=96.0,
+        tax=0.0,
+        total_amount=96.0,
+        deposit_amount=48.0,
+        balance_due=96.0,
+        deposit_due_date=date(2026, 4, 21),
+        balance_due_date=date(2026, 4, 22),
+        internal_notes="Repeatable BM-095 local browser validation fixture.",
+    )
+    order.items = [
+        OrderItem(
+            name="Preview Validation Cake",
+            description="Repeatable local validation order",
+            quantity=1,
+            unit_price=96.0,
+            total_price=96.0,
+        )
+    ]
+    session.add(order)
+    session.commit()
+    session.refresh(order)
+    return order
+
+
 async def seed_data():
     with Session(engine) as session:
-        user_service = UserService(session)
-
-        # Check if users already exist
-        users = session.query(User).all()
-        if users:
-            print("Database already seeded.")
-            return
-
-        # Create a user
-        user_in = UserCreate(email="test@example.com", password="password")
-        user = await user_service.create_user(user_in)
-
-        # Create recipes for the user
-        recipes_data = [
-            {
-                "name": "Classic Chocolate Chip Cookies",
-                "description": "The best chocolate chip cookies ever!",
-                "user_id": user.id,
-                "steps": "1. Preheat oven to 375°F (190°C). 2. Cream together butter, white sugar, and brown sugar until smooth. 3. Beat in the eggs one at a time, then stir in the vanilla. 4. Dissolve baking soda in hot water. Add to batter along with salt. 5. Stir in flour, chocolate chips, and nuts. 6. Drop by large spoonfuls onto ungreased pans. 7. Bake for about 10 minutes in the preheated oven, or until edges are nicely browned."
-            },
-            {
-                "name": "Sourdough Bread",
-                "description": "A crusty, chewy sourdough bread.",
-                "user_id": user.id,
-                "steps": "1. Feed your sourdough starter. 2. Mix the dough. 3. Bulk ferment. 4. Shape the dough. 5. Cold ferment. 6. Bake the bread."
-            },
-            {
-                "name": "New York-Style Pizza",
-                "description": "A classic New York-style pizza with a thin, crisp crust.",
-                "user_id": user.id,
-                "steps": "1. Make the dough. 2. Make the sauce. 3. Assemble the pizza. 4. Bake the pizza."
-            },
-        ]
-
-        for recipe_data in recipes_data:
-            recipe_in = RecipeCreate(**recipe_data)
-            session.add(Recipe(**recipe_in.model_dump(by_alias=False)))
-
-        session.commit()
-        print("Database seeded with a user and recipes.")
+        user = await ensure_seed_user(session)
+        ensure_seed_recipes(session, user=user)
+        validation_order = ensure_preview_validation_order(session, user=user)
+        print(
+            "Database seed ensured with preview validation user, recipes, "
+            f"and order {validation_order.order_number}."
+        )

--- a/backend/tests/unit/test_orders_bm006_service.py
+++ b/backend/tests/unit/test_orders_bm006_service.py
@@ -186,4 +186,4 @@ def test_order_service_prioritizes_nearest_due_and_builds_queue_risk_history(mon
         assert queue_order.balance_due_date == date(2026, 3, 13)
         assert queue_order.ops_summary.next_action == "Collect overdue deposit"
         assert queue_order.ops_summary.primary_cta_label == "Collect payment"
-        assert "Deposit due 2026-03-12" in queue_order.ops_summary.ops_attention
+        assert "Deposit due Mar 12, 2026" in queue_order.ops_summary.ops_attention

--- a/backend/tests/unit/test_orders_bm018_payment_focus.py
+++ b/backend/tests/unit/test_orders_bm018_payment_focus.py
@@ -61,6 +61,8 @@ def test_payment_focus_summary_prioritizes_overdue_deposit_context(monkeypatch):
     assert "Deposit is overdue." in order.payment_focus_summary.risk_note
     assert order.payment_focus_summary.next_step == "Collect overdue deposit"
     assert "Deposit due Mar 13, 2026" in order.payment_focus_summary.next_step_detail
+    assert order.payment_focus_summary.trust_state == "current"
+    assert order.payment_focus_summary.trust_label == "Current BakeMate payment context"
 
 
 def test_payment_focus_summary_shows_final_balance_after_deposit_is_paid(monkeypatch):

--- a/backend/tests/unit/test_orders_bm022_import_visibility.py
+++ b/backend/tests/unit/test_orders_bm022_import_visibility.py
@@ -530,6 +530,150 @@ def test_read_order_endpoint_returns_recent_customer_history_for_same_contact():
     assert payload.legacy_status_raw == "2.0"
 
 
+def test_read_orders_exposes_queue_payment_trust_cue_only_for_imported_legacy_limited_orders():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        current_user = User(
+            id=uuid4(),
+            email="bm062-queue@example.com",
+            hashed_password="not-used",
+            is_active=True,
+            is_superuser=False,
+        )
+        session.add(current_user)
+        session.add(
+            Order(
+                user_id=current_user.id,
+                customer_name="Imported Queue Trust",
+                order_number="LEG-QUEUE-1",
+                status=OrderStatus.CONFIRMED,
+                payment_status=PaymentStatus.UNPAID,
+                order_date=datetime(2026, 3, 7, 12, 0, tzinfo=timezone.utc),
+                due_date=datetime(2026, 3, 25, 12, 0, tzinfo=timezone.utc),
+                total_amount=150.0,
+                subtotal=150.0,
+                balance_due=150.0,
+                internal_notes=(
+                    "Legacy OrderStatusId: 2.0\n"
+                    "Legacy legacy_status_raw: 2.0\n"
+                    "Legacy bakemate_status: confirmed\n"
+                    "Legacy AmountPaid: 0"
+                ),
+            )
+        )
+        session.add(
+            Order(
+                user_id=current_user.id,
+                customer_name="Native Queue Trust",
+                order_number="ORD-QUEUE-1",
+                status=OrderStatus.CONFIRMED,
+                payment_status=PaymentStatus.UNPAID,
+                order_date=datetime(2026, 3, 8, 12, 0, tzinfo=timezone.utc),
+                due_date=datetime(2026, 3, 26, 12, 0, tzinfo=timezone.utc),
+                total_amount=90.0,
+                subtotal=90.0,
+                balance_due=90.0,
+                internal_notes="Created in BakeMate",
+            )
+        )
+        session.commit()
+
+        payload = asyncio.run(
+            read_orders(
+                session=session,
+                skip=0,
+                limit=100,
+                status_filter=None,
+                imported_only=None,
+                search=None,
+                needs_review=None,
+                review_reason=None,
+                current_user=current_user,
+            )
+        )
+
+    imported = next(order for order in payload if order.order_number == "LEG-QUEUE-1")
+    native = next(order for order in payload if order.order_number == "ORD-QUEUE-1")
+
+    assert imported.payment_focus_summary.trust_state == "legacy_limited"
+    assert imported.payment_focus_summary.historical_payment_label == "Historical payment: unknown"
+    assert "Legacy payment history may be incomplete" in imported.payment_focus_summary.historical_payment_note
+    assert imported.review_focus_summary.payment_trust_preview == "Payment trust: legacy-limited"
+    assert imported.day_running_focus_summary.queue_payment_trust_preview == "Payment trust: legacy-limited"
+    assert native.payment_focus_summary.trust_state == "current"
+    assert native.payment_focus_summary.historical_payment_label is None
+    assert native.payment_focus_summary.historical_payment_note is None
+    assert native.review_focus_summary.payment_trust_preview is None
+    assert native.day_running_focus_summary.queue_payment_trust_preview is None
+
+
+def test_imported_order_payment_focus_marks_legacy_limited_trust_boundary():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        current_user = User(
+            id=uuid4(),
+            email="bm061-imported@example.com",
+            hashed_password="not-used",
+            is_active=True,
+            is_superuser=False,
+        )
+        session.add(current_user)
+        session.add(
+            Order(
+                user_id=current_user.id,
+                customer_name="Imported Payment Trust",
+                customer_email="imported-payment@example.com",
+                order_number="LEG-PAY-1",
+                status=OrderStatus.CONFIRMED,
+                payment_status=PaymentStatus.UNPAID,
+                order_date=datetime(2026, 3, 7, 12, 0, tzinfo=timezone.utc),
+                due_date=datetime(2026, 3, 25, 12, 0, tzinfo=timezone.utc),
+                total_amount=150.0,
+                subtotal=150.0,
+                balance_due=150.0,
+                internal_notes=(
+                    "Legacy OrderStatusId: 2.0\n"
+                    "Legacy legacy_status_raw: 2.0\n"
+                    "Legacy bakemate_status: confirmed\n"
+                    "Legacy AmountPaid: 0"
+                ),
+            )
+        )
+        session.commit()
+        imported_order = session.exec(select(Order)).first()
+        assert imported_order is not None
+
+        payload = asyncio.run(
+            read_order(
+                session=session,
+                order_id=imported_order.id,
+                current_user=current_user,
+            )
+        )
+
+    assert payload is not None
+    assert payload.is_imported is True
+    assert payload.payment_focus_summary.trust_state == "legacy_limited"
+    assert payload.payment_focus_summary.trust_label == "Imported payment history is legacy-limited"
+    assert "conservative payment snapshot" in payload.payment_focus_summary.trust_note
+    assert payload.payment_focus_summary.historical_payment_label == "Historical payment: unknown"
+    assert "Use a second source" in payload.payment_focus_summary.historical_payment_note
+    assert payload.review_focus_summary.payment_trust_preview == "Payment trust: legacy-limited"
+    assert payload.day_running_focus_summary.queue_payment_trust_preview == "Payment trust: legacy-limited"
+
+
 def test_native_order_read_stays_safe_when_no_legacy_metadata_exists():
     engine = create_engine(
         "sqlite://",
@@ -582,3 +726,8 @@ def test_native_order_read_stays_safe_when_no_legacy_metadata_exists():
     assert payload.primary_review_reason is None
     assert payload.review_next_check is None
     assert payload.recent_customer_orders == []
+    assert payload.payment_focus_summary.trust_state == "current"
+    assert payload.payment_focus_summary.historical_payment_label is None
+    assert payload.payment_focus_summary.historical_payment_note is None
+    assert payload.review_focus_summary.payment_trust_preview is None
+    assert payload.day_running_focus_summary.queue_payment_trust_preview is None

--- a/backend/tests/unit/test_orders_bm028_review_focus.py
+++ b/backend/tests/unit/test_orders_bm028_review_focus.py
@@ -80,6 +80,7 @@ def test_review_focus_summary_surfaces_operator_at_a_glance_context(monkeypatch)
     assert order.review_focus_summary.payment_confidence == "Payment follow-up still risky — 384.00 remains open and dated money is overdue."
     assert order.review_focus_summary.invoice_confidence == "Invoice basics are complete."
     assert order.review_focus_summary.handoff_confidence == "Handoff basics are present, but timing should still be rechecked before release."
+    assert order.review_focus_summary.payment_trust_preview is None
     assert order.review_focus_summary.missing_basics == ["Payment follow-up is still blocking confidence."]
     assert order.review_focus_summary.risk_note == "Deposit is overdue. A large unpaid balance is still open."
     assert order.review_focus_summary.next_step == "Collect overdue deposit"
@@ -128,6 +129,7 @@ def test_review_focus_summary_calls_out_missing_cross_cutting_basics(monkeypatch
     assert order.review_focus_summary.payment_confidence == "Payment looks settled."
     assert order.review_focus_summary.invoice_confidence == "Invoice still needs attention: line items"
     assert order.review_focus_summary.handoff_confidence == "Confirm whether this order is pickup or delivery."
+    assert order.review_focus_summary.payment_trust_preview is None
     assert order.review_focus_summary.missing_basics == [
         "Add at least one customer contact method.",
         "Add line items so the order contents are clear.",
@@ -135,4 +137,4 @@ def test_review_focus_summary_calls_out_missing_cross_cutting_basics(monkeypatch
         "Invoice basics are incomplete for this order.",
     ]
     assert order.review_focus_summary.risk_note == "Add at least one customer contact method."
-    assert order.review_focus_summary.next_step == "Complete invoice details"
+    assert order.review_focus_summary.next_step == "Complete invoice basics"

--- a/backend/tests/unit/test_orders_bm033_day_running_focus.py
+++ b/backend/tests/unit/test_orders_bm033_day_running_focus.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timezone
 from uuid import uuid4
 
 import app.services.order_service as order_service_module
-from app.models.order import OrderCreate, OrderDayRunningFocusSummary, OrderItemCreate, OrderReviewFocusSummary, OrderStatus, OrderUpdate, PaymentStatus
+from app.models.order import OrderCreate, OrderDayRunningFocusSummary, OrderItemCreate, OrderPaymentFocusSummary, OrderReviewFocusSummary, OrderStatus, OrderUpdate, PaymentStatus
 from app.models.user import User
 from app.services.order_service import OrderService
 from sqlalchemy.pool import StaticPool
@@ -130,7 +130,7 @@ def test_bm033_day_running_focus_names_attention_preview(monkeypatch):
         "Deposit is still open (25.00) before handoff."
     )
     assert order.day_running_focus_summary.queue_reason_preview == (
-        "Attention: Deposit still open"
+        "Attention: Deposit due"
     )
     assert order.day_running_focus_summary.queue_next_step_preview == "Next: review deposit"
     assert order.day_running_focus_summary.queue_contact_preview == "Contact: call 555-111-3333"
@@ -299,7 +299,7 @@ def test_bm033_day_running_focus_previews_production_clue_when_next_step_is_prod
 
     assert order.day_running_focus_summary.readiness_label == "Needs attention today"
     assert order.day_running_focus_summary.primary_blocker_category == "production"
-    assert order.day_running_focus_summary.queue_next_step_preview == "Next: clarify bake details"
+    assert order.day_running_focus_summary.queue_next_step_preview == "Next: clarify production basics"
     assert order.day_running_focus_summary.queue_production_preview == "Production: flavor needs confirmation"
     assert order.production_focus_summary.readiness_label == "Needs clarification"
     assert order.production_focus_summary.attention_note == (
@@ -413,7 +413,7 @@ def test_bm042_day_running_focus_previews_invoice_clue_for_invoice_exception(mon
 
     assert order.day_running_focus_summary.readiness_label == "Blocked for today"
     assert order.day_running_focus_summary.primary_blocker_category == "invoice"
-    assert order.day_running_focus_summary.queue_reason_preview == "Blocked: Invoice details missing"
+    assert order.day_running_focus_summary.queue_reason_preview == "Blocked: Invoice basics missing"
     assert order.day_running_focus_summary.queue_next_step_preview == "Next: finish invoice"
     assert order.day_running_focus_summary.queue_invoice_preview == "Invoice: item totals need review"
     assert order.day_running_focus_summary.queue_payment_preview is None
@@ -464,7 +464,7 @@ def test_bm045_queue_next_step_preview_uses_consistent_action_shape_for_similar_
         assert service._build_queue_next_step_preview(
             next_step="Review final balance collection",
             reason_summary="Final balance is still open for today's handoff (140.00).",
-        ) == "Next: review balance collection"
+        ) == "Next: review final balance"
         assert service._build_queue_next_step_preview(
             next_step="Confirm delivery release details",
             reason_summary="Add the delivery destination before this order leaves the kitchen.",
@@ -488,11 +488,11 @@ def test_bm047_queue_reason_preview_names_targets_in_generic_fallback_cases():
         assert service._build_queue_reason_preview(
             readiness_label="Blocked for today",
             reason_summary="production basics missing",
-        ) == "Blocked: Bake details missing"
+        ) == "Blocked: Production basics missing"
         assert service._build_queue_reason_preview(
             readiness_label="Needs attention today",
             reason_summary="production details need clarification",
-        ) == "Attention: Bake details need clarification"
+        ) == "Attention: Production basics need clarification"
         assert service._build_queue_reason_preview(
             readiness_label="Blocked for today",
             reason_summary="contact basics missing",
@@ -507,7 +507,7 @@ def test_bm047_queue_reason_preview_names_targets_in_generic_fallback_cases():
         ) == "Blocked: Handoff method not confirmed"
 
 
-def test_bm048_queue_next_step_preview_uses_matching_bake_target_terms_for_production_exceptions():
+def test_bm048_queue_next_step_preview_uses_matching_production_basics_terms_for_production_exceptions():
     engine = create_engine(
         "sqlite://",
         connect_args={"check_same_thread": False},
@@ -520,11 +520,171 @@ def test_bm048_queue_next_step_preview_uses_matching_bake_target_terms_for_produ
         assert service._build_queue_next_step_preview(
             next_step="Lock the missing production basics",
             reason_summary="production basics missing",
-        ) == "Next: lock bake details"
+        ) == "Next: lock production basics"
         assert service._build_queue_next_step_preview(
             next_step="Confirm production details",
             reason_summary="production details need clarification",
-        ) == "Next: clarify bake details"
+        ) == "Next: clarify production basics"
+
+
+def test_bm055_queue_payment_preview_uses_compact_payment_family_terms():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        service = OrderService(session=session)
+        assert service._build_queue_reason_preview(
+            readiness_label="Needs attention today",
+            reason_summary="Deposit is still open (25.00) before handoff.",
+        ) == "Attention: Deposit due"
+        assert service._build_queue_reason_preview(
+            readiness_label="Needs attention today",
+            reason_summary="Final balance is still open for today's handoff (140.00).",
+        ) == "Attention: Final balance due"
+        assert service._build_queue_next_step_preview(
+            next_step="Review final balance collection",
+            reason_summary="Final balance is still open for today's handoff (140.00).",
+        ) == "Next: review final balance"
+        assert service._build_queue_next_step_preview(
+            next_step="Collect the overdue balance",
+            reason_summary="Final balance is overdue for today's work (140.00 open).",
+        ) == "Next: collect final balance"
+
+
+def test_bm057_queue_payment_amount_preview_uses_final_balance_wording():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        service = OrderService(session=session)
+        assert service._build_day_running_payment_preview(
+            readiness_label="Needs attention today",
+            primary_category="payment",
+            next_step="Review final balance collection",
+            payment_focus_summary=OrderPaymentFocusSummary(
+                amount_owed_now=140.0,
+                payment_state="Waiting on final balance",
+                collection_stage="balance",
+                deposit_status="Deposit paid",
+                balance_status="Final balance due",
+                due_timing="Next payment checkpoint: final balance on Mar 19, 2026.",
+                risk_note="Final balance still open.",
+                next_step="Collect final balance",
+                next_step_detail="Collect the remaining final balance before handoff.",
+            ),
+        ) == "Collect: $140.00 final balance"
+        assert service._build_day_running_payment_preview(
+            readiness_label="Needs attention today",
+            primary_category="payment",
+            next_step="Review deposit follow-up",
+            payment_focus_summary=OrderPaymentFocusSummary(
+                amount_owed_now=25.0,
+                payment_state="Waiting on deposit",
+                collection_stage="deposit",
+                deposit_status="Deposit due",
+                balance_status="Balance pending",
+                due_timing="Next payment checkpoint: deposit on Mar 19, 2026.",
+                risk_note="Deposit still open.",
+                next_step="Collect deposit",
+                next_step_detail="Collect the deposit before prep starts.",
+            ),
+        ) == "Collect: $25.00 deposit"
+
+
+def test_bm058_queue_payment_amount_preview_uses_compact_fallback_terms():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        service = OrderService(session=session)
+        assert service._build_day_running_payment_preview(
+            readiness_label="Needs attention today",
+            primary_category="payment",
+            next_step="Review final balance collection",
+            payment_focus_summary=OrderPaymentFocusSummary(
+                amount_owed_now=0.0,
+                payment_state="Paid in full",
+                collection_stage="settled",
+                deposit_status="Deposit collected",
+                balance_status="No balance remaining",
+                due_timing="No money is due right now.",
+                risk_note="No payment-specific risk flags right now.",
+                next_step="Share or archive the invoice record",
+                next_step_detail="The invoice is ready from the current order details and no money is still open.",
+            ),
+        ) == "Paid in full"
+        assert service._build_day_running_payment_preview(
+            readiness_label="Needs attention today",
+            primary_category="payment",
+            next_step="Review final balance collection",
+            payment_focus_summary=OrderPaymentFocusSummary(
+                amount_owed_now=80.0,
+                payment_state="Payment review needed",
+                collection_stage="review",
+                deposit_status="No deposit required",
+                balance_status="Final balance outstanding: $80.00 with no due date",
+                due_timing="Order is due today.",
+                risk_note="No payment-specific risk flags right now.",
+                next_step="Review final balance collection",
+                next_step_detail="Double-check the remaining amount before handoff.",
+            ),
+        ) == "Final balance review needed"
+        assert service._build_day_running_payment_preview(
+            readiness_label="Needs attention today",
+            primary_category="payment",
+            next_step="Review deposit follow-up",
+            payment_focus_summary=OrderPaymentFocusSummary(
+                amount_owed_now=20.0,
+                payment_state="Payment review needed",
+                collection_stage="review",
+                deposit_status="Deposit outstanding: $20.00 with no due date",
+                balance_status="Balance pending",
+                due_timing="Order is due today.",
+                risk_note="No payment-specific risk flags right now.",
+                next_step="Review deposit follow-up",
+                next_step_detail="Double-check the deposit amount before prep starts.",
+            ),
+        ) == "Deposit review needed"
+
+
+def test_bm056_queue_payment_preview_uses_compact_overdue_payment_terms():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        service = OrderService(session=session)
+        assert service._build_queue_reason_preview(
+            readiness_label="Needs attention today",
+            reason_summary="Deposit is still unpaid for today's work (25.00 open).",
+        ) == "Attention: Overdue deposit"
+        assert service._build_queue_reason_preview(
+            readiness_label="Needs attention today",
+            reason_summary="Final balance is overdue for today's work (140.00 open).",
+        ) == "Attention: Overdue final balance"
+        assert service._build_queue_next_step_preview(
+            next_step="Collect the overdue deposit",
+            reason_summary="Deposit is still unpaid for today's work (25.00 open).",
+        ) == "Next: collect deposit"
+        assert service._build_queue_next_step_preview(
+            next_step="Collect the overdue balance",
+            reason_summary="Final balance is overdue for today's work (140.00 open).",
+        ) == "Next: collect final balance"
 
 
 def test_bm033_day_running_focus_previews_final_balance_when_collection_is_current(monkeypatch):
@@ -587,8 +747,8 @@ def test_bm033_day_running_focus_previews_final_balance_when_collection_is_curre
 
     assert order is not None
     assert order.day_running_focus_summary.primary_blocker_category == "payment"
-    assert order.day_running_focus_summary.queue_next_step_preview == "Next: collect balance"
-    assert order.day_running_focus_summary.queue_payment_preview == "Collect: $140.00 balance"
+    assert order.day_running_focus_summary.queue_next_step_preview == "Next: collect final balance"
+    assert order.day_running_focus_summary.queue_payment_preview == "Collect: $140.00 final balance"
     assert order.day_running_focus_summary.queue_handoff_preview is None
 
 

--- a/backend/tests/unit/test_orders_bm066_local_dev_readiness.py
+++ b/backend/tests/unit/test_orders_bm066_local_dev_readiness.py
@@ -1,0 +1,99 @@
+import asyncio
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import OperationalError
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.api.v1.endpoints.orders import read_day_running_queue_summary, read_orders
+from app.models.order import DayRunningQueueSummary
+from app.models.user import User
+from app.services.order_service import OrderService
+from fastapi import HTTPException
+
+
+@pytest.fixture
+def session_and_user():
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        current_user = User(
+            id=uuid4(),
+            email="bm066@example.com",
+            hashed_password="not-used",
+            is_active=True,
+            is_superuser=False,
+        )
+        session.add(current_user)
+        session.commit()
+        yield session, current_user
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "method_name"),
+    [
+        (read_orders, "get_orders_by_user"),
+        (read_day_running_queue_summary, "get_day_running_queue_summary"),
+    ],
+)
+def test_ops_endpoints_surface_local_dev_readiness_for_stale_schema(
+    monkeypatch, session_and_user, endpoint, method_name
+):
+    session, current_user = session_and_user
+
+    async def raise_stale_schema(*args, **kwargs):
+        raise OperationalError(
+            'SELECT "order".customer_name FROM "order"',
+            {},
+            Exception("no such column: order.customer_name"),
+        )
+
+    monkeypatch.setattr(OrderService, method_name, raise_stale_schema)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(endpoint(session=session, current_user=current_user))
+
+    exc = exc_info.value
+    assert exc.status_code == 503
+    assert exc.detail["code"] == "local_dev_schema_stale"
+    assert exc.detail["title"] == "Local dev setup needs refresh"
+    assert "local BakeMate setup issue" in exc.detail["note"]
+    assert "schema refresh" in exc.detail["message"]
+    assert exc.detail["guidance_title"] == "How to recover locally"
+    assert exc.detail["guidance_source"] == "README.md and docs/developer_guide.md"
+    assert exc.detail["recovery_command_label"] == "Run locally from the BakeMate repo"
+    assert exc.detail["recovery_command"] == "docker compose up --build -d"
+    assert len(exc.detail["guidance_steps"]) == 3
+    assert "README.md or docs/developer_guide.md" in exc.detail["guidance_steps"][0]
+
+
+def test_ops_endpoints_keep_healthy_behavior_when_data_is_available(monkeypatch, session_and_user):
+    session, current_user = session_and_user
+
+    expected_orders = ["healthy-order"]
+    expected_summary = DayRunningQueueSummary(
+        all_count=4,
+        blocked_count=1,
+        needs_attention_count=2,
+        ready_count=1,
+    )
+
+    async def return_orders(*args, **kwargs):
+        return expected_orders
+
+    async def return_summary(*args, **kwargs):
+        return expected_summary
+
+    monkeypatch.setattr(OrderService, "get_orders_by_user", return_orders)
+    monkeypatch.setattr(OrderService, "get_day_running_queue_summary", return_summary)
+
+    orders_payload = asyncio.run(read_orders(session=session, current_user=current_user))
+    summary_payload = asyncio.run(
+        read_day_running_queue_summary(session=session, current_user=current_user)
+    )
+
+    assert orders_payload == expected_orders
+    assert summary_payload == expected_summary
+    assert not hasattr(orders_payload, "detail")
+    assert not hasattr(summary_payload, "detail")

--- a/backend/tests/unit/test_seed_preview_validation.py
+++ b/backend/tests/unit/test_seed_preview_validation.py
@@ -1,0 +1,45 @@
+import asyncio
+
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from app.models.order import Order
+from app.models.recipe import Recipe
+from app.models.user import User
+from seed import (
+    PREVIEW_VALIDATION_ORDER_NUMBER,
+    PREVIEW_VALIDATION_USER_EMAIL,
+    ensure_preview_validation_order,
+    ensure_seed_recipes,
+    ensure_seed_user,
+)
+
+
+def test_seed_helpers_create_repeatable_preview_validation_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        user = asyncio.run(ensure_seed_user(session))
+        ensure_seed_recipes(session, user=user)
+        order = ensure_preview_validation_order(session, user=user)
+
+        same_user = asyncio.run(ensure_seed_user(session))
+        ensure_seed_recipes(session, user=same_user)
+        same_order = ensure_preview_validation_order(session, user=same_user)
+
+        users = session.exec(select(User)).all()
+        recipes = session.exec(select(Recipe)).all()
+        orders = session.exec(select(Order)).all()
+
+        assert user.id == same_user.id
+        assert order.id == same_order.id
+        assert [user.email for user in users] == [PREVIEW_VALIDATION_USER_EMAIL]
+        assert len(recipes) == 3
+        assert len(orders) == 1
+        assert orders[0].order_number == PREVIEW_VALIDATION_ORDER_NUMBER
+        assert orders[0].items[0].name == "Preview Validation Cake"

--- a/frontend-next/.gitignore
+++ b/frontend-next/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+out
+coverage

--- a/frontend-next/README.md
+++ b/frontend-next/README.md
@@ -1,0 +1,25 @@
+# BakeMate frontend-next
+
+Parallel Next.js scaffold proof only.
+
+What this proves:
+- current form-encoded auth request compatibility
+- current localStorage token key compatibility (`token`)
+- authenticated `/ops` shell connectivity using the existing API
+
+What this does not claim:
+- replacement of the current frontend
+- `/orders` parity
+- order-detail parity
+
+## Run
+
+```bash
+cd frontend-next
+npm install
+NEXT_PUBLIC_API_URL=http://127.0.0.1:8001/api/v1 npm run dev
+```
+
+Then open:
+- `/login` to prove auth/token compatibility
+- `/ops` to prove authenticated shell connectivity

--- a/frontend-next/README.md
+++ b/frontend-next/README.md
@@ -3,14 +3,16 @@
 Parallel Next.js scaffold proof only.
 
 What this proves:
+- public landing page for a BobbyD-testable preview front door
 - current form-encoded auth request compatibility
 - current localStorage token key compatibility (`token`)
 - authenticated `/ops` shell connectivity using the existing API
+- reachable authenticated handoff into `/orders` and order detail preview
 
 What this does not claim:
 - replacement of the current frontend
-- `/orders` parity
-- order-detail parity
+- full frontend cutover
+- broader workflow parity beyond the accepted Next operator preview path
 
 ## Run
 
@@ -21,5 +23,7 @@ NEXT_PUBLIC_API_URL=http://127.0.0.1:8001/api/v1 npm run dev
 ```
 
 Then open:
+- `/` for the public preview landing page
 - `/login` to prove auth/token compatibility
 - `/ops` to prove authenticated shell connectivity
+- `/orders` for the authenticated queue preview

--- a/frontend-next/README.md
+++ b/frontend-next/README.md
@@ -19,11 +19,16 @@ What this does not claim:
 ```bash
 cd frontend-next
 npm install
-NEXT_PUBLIC_API_URL=http://127.0.0.1:8001/api/v1 npm run dev
+NEXT_PUBLIC_API_URL=http://127.0.0.1:8001/api/v1 npm run dev -- --hostname localhost --port 5173
 ```
 
 Then open:
-- `/` for the public preview landing page
+- `http://localhost:5173/` for the public preview landing page
 - `/login` to prove auth/token compatibility
 - `/ops` to prove authenticated shell connectivity
 - `/orders` for the authenticated queue preview
+
+The backend seed path creates `test@example.com` / `password` and one repeatable
+preview validation order. The default backend CORS origins include both
+`http://localhost:5173` and `http://127.0.0.1:5173`; keep the browser on one of
+those origins for the authenticated preview path.

--- a/frontend-next/app/globals.css
+++ b/frontend-next/app/globals.css
@@ -157,6 +157,42 @@ code {
   font-size: 12px;
 }
 
+.preview-validation-card {
+  border-color: #bfdbfe;
+  background: #f8fbff;
+}
+
+.validation-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.validation-item {
+  border: 1px solid #dbeafe;
+  border-radius: 12px;
+  padding: 14px;
+  background: #ffffff;
+}
+
+.validation-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  background: #dcfce7;
+  color: #166534;
+  font-weight: 700;
+}
+
+.feedback-prompt {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 14px;
+  background: #ffffff;
+  font-size: 13px;
+}
+
 .ops-row-side {
   gap: 6px;
   text-align: right;

--- a/frontend-next/app/globals.css
+++ b/frontend-next/app/globals.css
@@ -1,0 +1,259 @@
+:root {
+  color-scheme: light;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+.shell {
+  min-height: 100vh;
+  padding: 32px;
+}
+
+.card {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+
+.stack {
+  display: grid;
+  gap: 16px;
+}
+
+.row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.row.spread {
+  justify-content: space-between;
+}
+
+.row.start {
+  align-items: flex-start;
+}
+
+.grid {
+  display: grid;
+  gap: 16px;
+}
+
+.ops-layout {
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+.ops-main-grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 900px) {
+  .grid.cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1100px) {
+  .ops-main-grid {
+    grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.9fr);
+  }
+}
+
+.label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.value {
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  background: white;
+  cursor: pointer;
+}
+
+.button.primary {
+  background: #0f172a;
+  color: white;
+  border-color: #0f172a;
+}
+
+.button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  background: white;
+}
+
+.error {
+  color: #b91c1c;
+}
+
+.muted {
+  color: #475569;
+}
+
+.summary-card {
+  min-height: 120px;
+}
+
+.preview-row {
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 16px;
+  background: #fff;
+}
+
+.queue-preview-card {
+  padding: 14px;
+  min-width: 240px;
+}
+
+.queue-preview-meta {
+  font-size: 12px;
+}
+
+.ops-row-side {
+  gap: 6px;
+  text-align: right;
+}
+
+.ops-status-chip {
+  text-transform: uppercase;
+  font-size: 12px;
+}
+
+.ops-microcue {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.next-action-card {
+  display: grid;
+  gap: 10px;
+  background: #fffbeb;
+  border-color: #fde68a;
+}
+
+.readout-card {
+  padding: 14px;
+}
+
+.trust-readout {
+  background: #f0f9ff;
+  border-color: #bae6fd;
+}
+
+.trust-cue {
+  color: #0369a1;
+  margin-top: 8px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.trust-cue-neutral {
+  color: #334155;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.pill.urgent,
+.pill.danger {
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+.pill.today,
+.pill.warn {
+  background: #fef3c7;
+  border-color: #fde68a;
+  color: #92400e;
+}
+
+.pill.next,
+.pill.info {
+  background: #dbeafe;
+  border-color: #bfdbfe;
+  color: #1d4ed8;
+}
+
+.pill.default,
+.pill.neutral {
+  background: #e2e8f0;
+  border-color: #cbd5e1;
+  color: #334155;
+}
+
+.pill.violet {
+  background: #ede9fe;
+  border-color: #ddd6fe;
+  color: #6d28d9;
+}
+
+.tone-success {
+  background: #ecfdf5;
+  border-color: #bbf7d0;
+}
+
+.tone-warn {
+  background: #fffbeb;
+  border-color: #fde68a;
+}
+
+.tone-danger {
+  background: #fff1f2;
+  border-color: #fecdd3;
+}

--- a/frontend-next/app/layout.tsx
+++ b/frontend-next/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'BakeMate Next Scaffold',
+  description: 'Parallel Next.js scaffold proof for BakeMate auth and /ops shell.',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/frontend-next/app/login/page.tsx
+++ b/frontend-next/app/login/page.tsx
@@ -1,55 +1,12 @@
-'use client';
+import { LoginForm } from '@/components/login-form';
 
-import { FormEvent, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { loginWithPassword, writeStoredToken } from '@/lib/auth';
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>;
+}) {
+  const resolved = await searchParams;
+  const nextPath = resolved.next && resolved.next.startsWith('/') ? resolved.next : '/ops';
 
-export default function LoginPage() {
-  const router = useRouter();
-  const [username, setUsername] = useState('admin@example.com');
-  const [password, setPassword] = useState('password');
-  const [error, setError] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setIsSubmitting(true);
-    setError(null);
-
-    try {
-      const result = await loginWithPassword(username, password);
-      writeStoredToken(result.access_token);
-      router.push('/ops');
-    } catch {
-      setError('Login proof failed. Check API availability and credentials.');
-    } finally {
-      setIsSubmitting(false);
-    }
-  }
-
-  return (
-    <main className="shell">
-      <div className="card stack" style={{ maxWidth: 480 }}>
-        <div className="label">Auth compatibility proof</div>
-        <h1 style={{ margin: 0 }}>Sign in with the current token flow</h1>
-        <p className="muted" style={{ margin: 0 }}>
-          This scaffold uses the same form-encoded login request shape and the same localStorage token key as the current frontend.
-        </p>
-        <form className="stack" onSubmit={handleSubmit}>
-          <label className="stack" style={{ gap: 8 }}>
-            <span className="label">Username</span>
-            <input className="input" value={username} onChange={(event) => setUsername(event.target.value)} />
-          </label>
-          <label className="stack" style={{ gap: 8 }}>
-            <span className="label">Password</span>
-            <input className="input" type="password" value={password} onChange={(event) => setPassword(event.target.value)} />
-          </label>
-          <button className="button primary" disabled={isSubmitting} type="submit">
-            {isSubmitting ? 'Signing in…' : 'Sign in'}
-          </button>
-        </form>
-        {error ? <div className="error">{error}</div> : null}
-      </div>
-    </main>
-  );
+  return <LoginForm nextPath={nextPath} />;
 }

--- a/frontend-next/app/login/page.tsx
+++ b/frontend-next/app/login/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { loginWithPassword, writeStoredToken } from '@/lib/auth';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState('admin@example.com');
+  const [password, setPassword] = useState('password');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const result = await loginWithPassword(username, password);
+      writeStoredToken(result.access_token);
+      router.push('/ops');
+    } catch {
+      setError('Login proof failed. Check API availability and credentials.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="shell">
+      <div className="card stack" style={{ maxWidth: 480 }}>
+        <div className="label">Auth compatibility proof</div>
+        <h1 style={{ margin: 0 }}>Sign in with the current token flow</h1>
+        <p className="muted" style={{ margin: 0 }}>
+          This scaffold uses the same form-encoded login request shape and the same localStorage token key as the current frontend.
+        </p>
+        <form className="stack" onSubmit={handleSubmit}>
+          <label className="stack" style={{ gap: 8 }}>
+            <span className="label">Username</span>
+            <input className="input" value={username} onChange={(event) => setUsername(event.target.value)} />
+          </label>
+          <label className="stack" style={{ gap: 8 }}>
+            <span className="label">Password</span>
+            <input className="input" type="password" value={password} onChange={(event) => setPassword(event.target.value)} />
+          </label>
+          <button className="button primary" disabled={isSubmitting} type="submit">
+            {isSubmitting ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+        {error ? <div className="error">{error}</div> : null}
+      </div>
+    </main>
+  );
+}

--- a/frontend-next/app/ops/page.tsx
+++ b/frontend-next/app/ops/page.tsx
@@ -1,0 +1,9 @@
+import { OpsShellProof } from '@/components/ops-shell-proof';
+
+export default function OpsPage() {
+  return (
+    <main className="shell">
+      <OpsShellProof />
+    </main>
+  );
+}

--- a/frontend-next/app/orders/[orderId]/page.tsx
+++ b/frontend-next/app/orders/[orderId]/page.tsx
@@ -1,0 +1,6 @@
+import { OrderDetailEntry } from '@/components/order-detail-entry';
+
+export default async function OrderDetailPage({ params }: { params: Promise<{ orderId: string }> }) {
+  const { orderId } = await params;
+  return <OrderDetailEntry orderId={orderId} />;
+}

--- a/frontend-next/app/orders/page.tsx
+++ b/frontend-next/app/orders/page.tsx
@@ -1,0 +1,9 @@
+import { OrdersQueue } from '@/components/orders-queue';
+
+export default function OrdersPage() {
+  return (
+    <main className="shell">
+      <OrdersQueue />
+    </main>
+  );
+}

--- a/frontend-next/app/page.tsx
+++ b/frontend-next/app/page.tsx
@@ -1,26 +1,61 @@
 import Link from 'next/link';
+import { buildLoginHref } from '@/lib/auth';
+
+const previewSteps = [
+  {
+    label: '1. Land here',
+    detail: 'Start from one honest public front door for BobbyD testing.',
+  },
+  {
+    label: '2. Sign in',
+    detail: 'Use the current BakeMate auth contract and token storage shape.',
+  },
+  {
+    label: '3. Enter /ops',
+    detail: 'Arrive in the accepted Next operator preview, then continue into queue and order detail.',
+  },
+];
 
 export default function HomePage() {
   return (
     <main className="shell">
-      <div className="card stack" style={{ maxWidth: 720 }}>
-        <div className="label">Parallel scaffold proof</div>
-        <h1 style={{ margin: 0 }}>BakeMate Next.js scaffold</h1>
-        <p className="muted" style={{ margin: 0 }}>
-          This parallel app now proves current auth/token compatibility, an authenticated `/ops` front door, and a first real `/orders` queue parity entry.
-          It still does not replace the current frontend or claim order-detail parity.
-        </p>
-        <div className="row">
-          <Link className="button primary" href="/login">
-            Go to login proof
-          </Link>
-          <Link className="button" href="/ops">
-            Go to /ops
-          </Link>
-          <Link className="button" href="/orders">
-            Go to /orders
-          </Link>
-        </div>
+      <div className="stack" style={{ maxWidth: 880 }}>
+        <section className="card stack">
+          <div className="label">BM-093 live-testable preview front door</div>
+          <h1 style={{ margin: 0 }}>BakeMate preview</h1>
+          <p className="muted" style={{ margin: 0 }}>
+            This Next app is now the first real BobbyD-testable front door for a bounded preview path: public landing, reachable login,
+            authenticated `/ops`, queue handoff, and order-detail drill-in. React/Vite still remains the trusted live frontend.
+          </p>
+          <div className="row">
+            <Link className="button primary" href={buildLoginHref('/ops')}>
+              Sign in to preview
+            </Link>
+            <Link className="button" href="/ops">
+              Open /ops preview
+            </Link>
+            <Link className="button" href="/orders">
+              Open queue preview
+            </Link>
+          </div>
+        </section>
+
+        <section className="grid cols-3">
+          {previewSteps.map((step) => (
+            <article className="card" key={step.label}>
+              <div className="label">{step.label}</div>
+              <div className="muted" style={{ marginTop: 10 }}>{step.detail}</div>
+            </article>
+          ))}
+        </section>
+
+        <section className="card stack">
+          <div className="label">Honest scope</div>
+          <p className="muted" style={{ margin: 0 }}>
+            This is a real testable preview front door, not a full frontend cutover claim. The accepted Next operator path is `/ops` → `/orders` → order detail,
+            and anything beyond that still truthfully hands off to the current app.
+          </p>
+        </section>
       </div>
     </main>
   );

--- a/frontend-next/app/page.tsx
+++ b/frontend-next/app/page.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <main className="shell">
+      <div className="card stack" style={{ maxWidth: 720 }}>
+        <div className="label">Parallel scaffold proof</div>
+        <h1 style={{ margin: 0 }}>BakeMate Next.js scaffold</h1>
+        <p className="muted" style={{ margin: 0 }}>
+          This parallel app now proves current auth/token compatibility, an authenticated `/ops` front door, and a first real `/orders` queue parity entry.
+          It still does not replace the current frontend or claim order-detail parity.
+        </p>
+        <div className="row">
+          <Link className="button primary" href="/login">
+            Go to login proof
+          </Link>
+          <Link className="button" href="/ops">
+            Go to /ops
+          </Link>
+          <Link className="button" href="/orders">
+            Go to /orders
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend-next/components/auth-required-card.tsx
+++ b/frontend-next/components/auth-required-card.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import { buildLoginHref } from '@/lib/auth';
+
+export function AuthRequiredCard({
+  nextPath,
+  title = 'Sign in required',
+  detail,
+}: {
+  nextPath: string;
+  title?: string;
+  detail: string;
+}) {
+  return (
+    <section className="card stack" style={{ maxWidth: 720 }}>
+      <div className="label">Authenticated preview</div>
+      <h1 style={{ margin: 0 }}>{title}</h1>
+      <p className="muted" style={{ margin: 0 }}>{detail}</p>
+      <div className="row">
+        <Link className="button primary" href={buildLoginHref(nextPath)}>
+          Go to login
+        </Link>
+        <Link className="button" href="/">
+          Back to landing
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/frontend-next/components/login-form.tsx
+++ b/frontend-next/components/login-form.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import Link from 'next/link';
+import { FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { loginWithPassword, writeStoredToken } from '@/lib/auth';
+
+export function LoginForm({ nextPath }: { nextPath: string }) {
+  const router = useRouter();
+  const [username, setUsername] = useState('admin@example.com');
+  const [password, setPassword] = useState('password');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const result = await loginWithPassword(username, password);
+      writeStoredToken(result.access_token);
+      router.push(nextPath);
+    } catch {
+      setError('Login preview failed. Check API availability and credentials.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="shell">
+      <div className="card stack" style={{ maxWidth: 480 }}>
+        <div className="label">Preview login</div>
+        <h1 style={{ margin: 0 }}>Sign in with the current token flow</h1>
+        <p className="muted" style={{ margin: 0 }}>
+          This preview uses the same form-encoded login request shape and the same localStorage token key as the current frontend,
+          then hands off into the requested authenticated preview route.
+        </p>
+        <div className="card" style={{ padding: 14 }}>
+          <div className="label">After sign-in</div>
+          <div className="muted" style={{ marginTop: 8 }}>You will continue to <code>{nextPath}</code>.</div>
+        </div>
+        <form className="stack" onSubmit={handleSubmit}>
+          <label className="stack" style={{ gap: 8 }}>
+            <span className="label">Username</span>
+            <input className="input" value={username} onChange={(event) => setUsername(event.target.value)} />
+          </label>
+          <label className="stack" style={{ gap: 8 }}>
+            <span className="label">Password</span>
+            <input className="input" type="password" value={password} onChange={(event) => setPassword(event.target.value)} />
+          </label>
+          <button className="button primary" disabled={isSubmitting} type="submit">
+            {isSubmitting ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+        {error ? <div className="error">{error}</div> : null}
+        <div className="row">
+          <Link className="button" href="/">
+            Back to landing
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend-next/components/login-form.tsx
+++ b/frontend-next/components/login-form.tsx
@@ -7,7 +7,7 @@ import { loginWithPassword, writeStoredToken } from '@/lib/auth';
 
 export function LoginForm({ nextPath }: { nextPath: string }) {
   const router = useRouter();
-  const [username, setUsername] = useState('admin@example.com');
+  const [username, setUsername] = useState('test@example.com');
   const [password, setPassword] = useState('password');
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/frontend-next/components/ops-shell-proof.tsx
+++ b/frontend-next/components/ops-shell-proof.tsx
@@ -22,6 +22,13 @@ import {
   getQueueBadge,
   humanizeStatus,
 } from '@/lib/queue-ui';
+import {
+  PREVIEW_VALIDATION_CHECKS,
+  PREVIEW_VALIDATION_FEEDBACK_PROMPT,
+  getPreviewValidationFeedbackHref,
+  getPreviewValidationPathLabel,
+  getPreviewValidationStateLabel,
+} from '@/lib/preview-validation';
 
 function getSummaryCards(summary: DayRunningSummary | null) {
   return [
@@ -125,8 +132,9 @@ export function OpsShellProof() {
             <div className="label">Preview</div>
             <h1 style={{ margin: '8px 0 0' }}>Ops Home</h1>
             <p className="muted" style={{ maxWidth: 860, marginBottom: 0 }}>
-              A visible front door for BakeMate’s trusted day-running view. This parity-first Next.js slice preserves
-              the accepted `/ops` structure and meaning and now hands off into a real Next `/orders` queue, while still leaving order detail in the current app.
+              A visible front door for BakeMate's trusted day-running view. This parity-first Next.js slice preserves
+              the accepted `/ops` structure and meaning and now hands off into a real Next `/orders` queue and order-detail entry.
+              React/Vite remains the trusted live frontend.
             </p>
           </div>
           <div className="row">
@@ -143,6 +151,40 @@ export function OpsShellProof() {
               </button>
             )}
           </div>
+        </div>
+      </section>
+
+      <section className="card stack preview-validation-card" aria-labelledby="preview-validation-title">
+        <div className="row spread start">
+          <div>
+            <div className="label">BM-094 preview validation</div>
+            <h2 id="preview-validation-title" style={{ margin: '8px 0 0' }}>What to test in Next</h2>
+            <p className="muted" style={{ maxWidth: 900, marginBottom: 0 }}>
+              Validate the accepted BM-093 click-through path: {getPreviewValidationPathLabel()}.
+              This is a bounded Next preview, not a cutover or full parity claim.
+            </p>
+          </div>
+          <a className="button" href={getPreviewValidationFeedbackHref()}>
+            Report mismatch
+          </a>
+        </div>
+
+        <div className="grid validation-grid">
+          {PREVIEW_VALIDATION_CHECKS.map((check) => (
+            <article className="validation-item" key={check.label}>
+              <div className="row" style={{ gap: 8 }}>
+                <span className="validation-mark" aria-hidden="true">✓</span>
+                <span className="pill neutral">{getPreviewValidationStateLabel(check.state)}</span>
+              </div>
+              <div style={{ fontWeight: 700, marginTop: 10 }}>{check.label}</div>
+              <div className="muted" style={{ marginTop: 6 }}>{check.detail}</div>
+            </article>
+          ))}
+        </div>
+
+        <div className="feedback-prompt">
+          <div className="label">Mismatch note prompt</div>
+          <div style={{ marginTop: 6 }}>{PREVIEW_VALIDATION_FEEDBACK_PROMPT}</div>
         </div>
       </section>
 

--- a/frontend-next/components/ops-shell-proof.tsx
+++ b/frontend-next/components/ops-shell-proof.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
+import { AuthRequiredCard } from '@/components/auth-required-card';
 import { readStoredToken } from '@/lib/auth';
 import { fetchDayRunningSummary, fetchOpsPreviewOrders, type DayRunningSummary, type OpsPreviewOrder } from '@/lib/ops';
 import {
@@ -106,6 +107,15 @@ export function OpsShellProof() {
     [topOrders],
   );
   const importedReviewHref = getCurrentFrontendHref('/orders/imported');
+
+  if (error === 'Missing auth token') {
+    return (
+      <AuthRequiredCard
+        nextPath="/ops"
+        detail="Sign in first to open the accepted Next /ops preview, then continue into the queue and order detail path."
+      />
+    );
+  }
 
   return (
     <div className="stack ops-layout">

--- a/frontend-next/components/ops-shell-proof.tsx
+++ b/frontend-next/components/ops-shell-proof.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { readStoredToken } from '@/lib/auth';
+import { fetchDayRunningSummary, fetchOpsPreviewOrders, type DayRunningSummary, type OpsPreviewOrder } from '@/lib/ops';
+import {
+  getOpsQueuePreviewDrillInAffordanceLabel,
+  getOpsQueuePreviewPriorityLabel,
+  getOpsQueuePreviewRowNextStepCue,
+  getOpsQueuePreviewRowPriorityCue,
+  getOpsQueuePreviewRowReasonCue,
+  getOpsQueuePreviewScopeLabel,
+} from '@/lib/ops-preview';
+import {
+  formatBakeryDateTime,
+  formatMoney,
+  getActionClassMeta,
+  getCurrentFrontendHref,
+  getDayRunningPanelTone,
+  getQueueBadge,
+  humanizeStatus,
+} from '@/lib/queue-ui';
+
+function getSummaryCards(summary: DayRunningSummary | null) {
+  return [
+    ['Visible day-running work', summary?.all_count ?? '—'],
+    ['Blocked for today', summary?.blocked_count ?? '—'],
+    ['Needs attention', summary?.needs_attention_count ?? '—'],
+    ['Ready now', summary?.ready_count ?? '—'],
+  ];
+}
+
+
+function getAttentionHeadline(summary: DayRunningSummary | null) {
+  if (!summary) {
+    return 'Loading today’s ops view…';
+  }
+
+  if (summary.blocked_count > 0) {
+    return `${summary.blocked_count} blocked ${summary.blocked_count === 1 ? 'order needs' : 'orders need'} help first.`;
+  }
+
+  if (summary.needs_attention_count > 0) {
+    return `${summary.needs_attention_count} ${summary.needs_attention_count === 1 ? 'order needs' : 'orders need'} attention next.`;
+  }
+
+  if (summary.ready_count > 0) {
+    return `${summary.ready_count} ${summary.ready_count === 1 ? 'order is' : 'orders are'} ready to work now.`;
+  }
+
+  return 'No day-running work is currently visible in this preview.';
+}
+
+function getTopAttentionOrders(orders: OpsPreviewOrder[]) {
+  return [...orders]
+    .sort((left, right) => {
+      const urgencyDelta = left.queue_summary.urgency_rank - right.queue_summary.urgency_rank;
+      if (urgencyDelta !== 0) {
+        return urgencyDelta;
+      }
+
+      return new Date(left.due_date).getTime() - new Date(right.due_date).getTime();
+    })
+    .slice(0, 6);
+}
+
+export function OpsShellProof() {
+  const [summary, setSummary] = useState<DayRunningSummary | null>(null);
+  const [orders, setOrders] = useState<OpsPreviewOrder[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const token = readStoredToken();
+        if (!token) {
+          throw new Error('Missing auth token');
+        }
+
+        const [nextSummary, nextOrders] = await Promise.all([fetchDayRunningSummary(), fetchOpsPreviewOrders()]);
+        setSummary(nextSummary);
+        setOrders(nextOrders);
+      } catch (nextError) {
+        setError(nextError instanceof Error ? nextError.message : 'Unable to load authenticated /ops');
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    void load();
+  }, []);
+
+  const summaryCards = useMemo(() => getSummaryCards(summary), [summary]);
+  const topOrders = useMemo(() => getTopAttentionOrders(orders), [orders]);
+  const blockedOrders = useMemo(
+    () => topOrders.filter((order) => order.day_running_focus_summary.readiness_label === 'Blocked for today').slice(0, 3),
+    [topOrders],
+  );
+  const attentionOrders = useMemo(
+    () => topOrders.filter((order) => order.day_running_focus_summary.readiness_label === 'Needs attention today').slice(0, 3),
+    [topOrders],
+  );
+  const importedReviewHref = getCurrentFrontendHref('/orders/imported');
+
+  return (
+    <div className="stack ops-layout">
+      <section className="card stack">
+        <div className="row spread start">
+          <div>
+            <div className="label">Preview</div>
+            <h1 style={{ margin: '8px 0 0' }}>Ops Home</h1>
+            <p className="muted" style={{ maxWidth: 860, marginBottom: 0 }}>
+              A visible front door for BakeMate’s trusted day-running view. This parity-first Next.js slice preserves
+              the accepted `/ops` structure and meaning and now hands off into a real Next `/orders` queue, while still leaving order detail in the current app.
+            </p>
+          </div>
+          <div className="row">
+            <Link className="button" href="/orders">
+              View full queue
+            </Link>
+            {importedReviewHref ? (
+              <a className="button primary" href={importedReviewHref}>
+                Imported review
+              </a>
+            ) : (
+              <button className="button primary" disabled title="Set NEXT_PUBLIC_CURRENT_FRONTEND_URL to wire the current app route">
+                Imported review
+              </button>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {error ? <section className="card error">{error}</section> : null}
+
+      <section className="grid cols-4">
+        {summaryCards.map(([label, value]) => (
+          <article className="card summary-card" key={String(label)}>
+            <div className="label">{label}</div>
+            <div className="value">{isLoading ? '…' : value}</div>
+          </article>
+        ))}
+      </section>
+
+      <section className="ops-main-grid">
+        <section className="card stack">
+          <div className="row spread start">
+            <div>
+              <h2 style={{ margin: 0 }}>What needs attention now</h2>
+              <p className="muted" style={{ margin: '6px 0 0' }}>{getAttentionHeadline(summary)}</p>
+            </div>
+            <div className="card queue-preview-card">
+              <div className="label">Queue preview</div>
+              <div className="value" style={{ fontSize: 24 }}>{topOrders.length}</div>
+              <div className="muted queue-preview-meta">{getOpsQueuePreviewPriorityLabel()}</div>
+              <div className="muted queue-preview-meta">{getOpsQueuePreviewScopeLabel(topOrders.length)}</div>
+              <div className="muted queue-preview-meta">{getOpsQueuePreviewDrillInAffordanceLabel()}</div>
+            </div>
+          </div>
+
+          {isLoading ? <div className="muted">Loading authenticated /ops preview…</div> : null}
+          {!isLoading && !error && topOrders.length === 0 ? (
+            <div className="muted">No visible ops work is currently available.</div>
+          ) : null}
+
+          <div className="stack">
+            {topOrders.map((order) => {
+              const queueBadge = getQueueBadge(order);
+              const actionClassMeta = getActionClassMeta(order.ops_summary.action_class);
+              const priorityCue = getOpsQueuePreviewRowPriorityCue(order.queue_summary.urgency_label);
+              const reasonCue = getOpsQueuePreviewRowReasonCue(
+                order.day_running_focus_summary.readiness_label,
+                order.day_running_focus_summary.queue_reason_preview,
+              );
+              const nextStepCue = getOpsQueuePreviewRowNextStepCue(
+                order.day_running_focus_summary.readiness_label,
+                order.day_running_focus_summary.queue_next_step_preview,
+              );
+
+              return (
+                <article className="preview-row stack" key={order.id} style={{ gap: 14 }}>
+                  <div className="row spread start">
+                    <div className="stack" style={{ gap: 8 }}>
+                      <div className="row" style={{ gap: 8 }}>
+                        <div style={{ fontWeight: 700 }}>{order.order_number}</div>
+                        <span className={`pill ${queueBadge.tone}`}>{queueBadge.label}</span>
+                        <span className={`pill ${actionClassMeta.tone}`}>{actionClassMeta.label}</span>
+                      </div>
+                      <div className="muted">{order.customer_summary.name || order.customer_summary.email || 'No customer'}</div>
+                      <div className="muted">Due {formatBakeryDateTime(order.due_date)} · {order.delivery_method || 'delivery TBD'}</div>
+                    </div>
+                    <div className="stack ops-row-side">
+                      <div style={{ fontWeight: 700 }}>{formatMoney(order.total_amount)}</div>
+                      <div className="muted ops-status-chip">{humanizeStatus(order.payment_status)}</div>
+                      <div>
+                        <span className={`pill ${priorityCue.tone}`}>{priorityCue.label}</span>
+                      </div>
+                      {reasonCue ? <div className="muted ops-microcue">{reasonCue}</div> : null}
+                      {nextStepCue ? <div className="muted ops-microcue">{nextStepCue}</div> : null}
+                    </div>
+                  </div>
+
+                  <div className={`card tone-${getDayRunningPanelTone(order.day_running_focus_summary.readiness_label)}`}>
+                    <div className="label">Day-running readiness</div>
+                    <div style={{ fontWeight: 700, marginTop: 6 }}>{order.day_running_focus_summary.readiness_label}</div>
+                    <div className="muted" style={{ marginTop: 6 }}>
+                      {order.day_running_focus_summary.queue_reason_preview || order.day_running_focus_summary.reason_summary}
+                    </div>
+                    {order.day_running_focus_summary.primary_blocker_label ? (
+                      <div className="muted" style={{ marginTop: 8, fontSize: 12, fontWeight: 600 }}>
+                        {order.day_running_focus_summary.primary_blocker_label}
+                      </div>
+                    ) : null}
+                    {order.day_running_focus_summary.queue_payment_trust_preview ? (
+                      <div className="trust-cue">{order.day_running_focus_summary.queue_payment_trust_preview}</div>
+                    ) : null}
+                  </div>
+
+                  <div className="card next-action-card">
+                    <div>
+                      <div className="label">Next action</div>
+                      <div style={{ fontWeight: 700, marginTop: 6 }}>{order.ops_summary.next_action}</div>
+                      <div className="muted" style={{ marginTop: 6 }}>{order.ops_summary.ops_attention}</div>
+                    </div>
+                    {order.ops_summary.primary_cta_path ? (
+                      <div className="muted" style={{ fontSize: 12 }}>
+                        Current app CTA preserved: <code>{order.ops_summary.primary_cta_label}</code> via{' '}
+                        <code>{order.ops_summary.primary_cta_path}</code>
+                      </div>
+                    ) : null}
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <aside className="stack">
+          <section className="card stack">
+            <h2 style={{ margin: 0 }}>Ops readout</h2>
+            <div className="card readout-card">
+              <div className="label">Blocked first</div>
+              <div style={{ marginTop: 8 }}>
+                {blockedOrders.length > 0
+                  ? blockedOrders.map((order) => order.order_number).join(', ')
+                  : 'No blocked orders in the current queue preview.'}
+              </div>
+            </div>
+            <div className="card readout-card">
+              <div className="label">Attention next</div>
+              <div style={{ marginTop: 8 }}>
+                {attentionOrders.length > 0
+                  ? attentionOrders.map((order) => order.order_number).join(', ')
+                  : 'No needs-attention orders in the current queue preview.'}
+              </div>
+            </div>
+            <div className="card readout-card trust-readout">
+              <div className="label">Imported payment trust</div>
+              <div style={{ marginTop: 8 }}>
+                Imported orders keep the accepted payment trust boundary visible here as
+                <strong> Payment trust: legacy-limited</strong>.
+              </div>
+              <div className="muted" style={{ marginTop: 8, fontSize: 12 }}>
+                This preview stays informational only. It does not invent stronger historical payment certainty.
+              </div>
+            </div>
+            <div className="muted" style={{ fontSize: 12 }}>
+              BM-083 preserves the current `/ops` front-door meaning while keeping non-`/ops` routes in the current app.
+            </div>
+            <div className="muted" style={{ fontSize: 12 }}>
+              {getCurrentFrontendHref('/orders') ? (
+                <>Current app detail handoff is still available via <code>NEXT_PUBLIC_CURRENT_FRONTEND_URL</code>.</>
+              ) : (
+                <>Set <code>NEXT_PUBLIC_CURRENT_FRONTEND_URL</code> to turn non-migrated order-detail CTAs into real current-app handoff links.</>
+              )}
+            </div>
+          </section>
+        </aside>
+      </section>
+    </div>
+  );
+}

--- a/frontend-next/components/order-detail-entry.tsx
+++ b/frontend-next/components/order-detail-entry.tsx
@@ -1,0 +1,393 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { fetchOrderDetail, type OrderDetailRecord } from '@/lib/orders';
+import { getHandoffContactLines, getHandoffDestinationSummary, getHandoffMethodTone } from '@/lib/handoff-panel';
+import { describeImportReviewReason, getImportedReviewReasons, getImportedReviewSummary } from '@/lib/imported-review-panel';
+import { humanizeInvoiceStatus, getInvoiceReadinessTone } from '@/lib/invoice-panel';
+import { describeAmountOwedNow, getPaymentTrustTone } from '@/lib/payment-panel';
+import { getReviewCueRows, getReviewPrimaryBlocker } from '@/lib/review-panel';
+import { formatBakeryDateTime, formatMoney, getCurrentFrontendHref, humanizeStatus } from '@/lib/queue-ui';
+
+export function OrderDetailEntry({ orderId }: { orderId: string }) {
+  const [order, setOrder] = useState<OrderDetailRecord | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const nextOrder = await fetchOrderDetail(orderId);
+        setOrder(nextOrder);
+      } catch (nextError) {
+        setError(nextError instanceof Error ? nextError.message : 'Unable to load order detail');
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    void load();
+  }, [orderId]);
+
+  if (isLoading) {
+    return (
+      <main className="shell">
+        <section className="card muted">Loading authenticated order detail…</section>
+      </main>
+    );
+  }
+
+  if (error || !order) {
+    return (
+      <main className="shell">
+        <section className="card error">{error || 'Order detail unavailable.'}</section>
+      </main>
+    );
+  }
+
+  const currentAppHref = getCurrentFrontendHref(order.ops_summary.primary_cta_path || `/orders/${order.id}`);
+  const reviewCues = getReviewCueRows(order);
+  const primaryBlocker = getReviewPrimaryBlocker(order);
+  const paymentTrustTone = getPaymentTrustTone(order);
+  const invoiceReadinessTone = getInvoiceReadinessTone(order);
+  const handoffMethodTone = getHandoffMethodTone(order.handoff_focus_summary.method_status);
+  const handoffContactLines = getHandoffContactLines(order);
+  const handoffDestinationSummary = getHandoffDestinationSummary(order);
+  const importedReviewSummary = getImportedReviewSummary(order);
+  const importedReviewReasons = getImportedReviewReasons(order);
+
+  return (
+    <main className="shell">
+      <div className="stack">
+        <section className="card stack">
+          <div className="row spread start">
+            <div>
+              <div className="label">Order detail entry</div>
+              <h1 style={{ margin: '8px 0 0' }}>{order.order_number}</h1>
+              <p className="muted" style={{ marginBottom: 0 }}>
+                BM-086 upgrades the Next detail entry into a real review-first working surface while keeping deeper order
+                work honestly handed off to the current app.
+              </p>
+            </div>
+            <div className="row">
+              <Link className="button" href="/orders">Back to queue</Link>
+              {currentAppHref ? <a className="button primary" href={currentAppHref}>Continue in current app</a> : null}
+            </div>
+          </div>
+        </section>
+
+        <section className="grid cols-4">
+          <article className="card">
+            <div className="label">Customer</div>
+            <div style={{ fontWeight: 700, marginTop: 6 }}>{order.review_focus_summary.customer_name}</div>
+            <div className="muted" style={{ marginTop: 6 }}>{order.customer_summary.email || order.customer_summary.phone || 'No contact detail'}</div>
+          </article>
+          <article className="card">
+            <div className="label">Due</div>
+            <div style={{ fontWeight: 700, marginTop: 6 }}>{order.review_focus_summary.due_label || formatBakeryDateTime(order.due_date)}</div>
+            <div className="muted" style={{ marginTop: 6 }}>{order.delivery_method || 'delivery TBD'}</div>
+          </article>
+          <article className="card">
+            <div className="label">Status</div>
+            <div style={{ fontWeight: 700, marginTop: 6 }}>{order.review_focus_summary.status_label || humanizeStatus(order.status)}</div>
+            <div className="muted" style={{ marginTop: 6 }}>{humanizeStatus(order.payment_status)}</div>
+          </article>
+          <article className="card">
+            <div className="label">Total</div>
+            <div style={{ fontWeight: 700, marginTop: 6 }}>{formatMoney(order.total_amount)}</div>
+            <div className="muted" style={{ marginTop: 6 }}>{order.review_focus_summary.item_count_label}</div>
+          </article>
+        </section>
+
+        <section className="card stack">
+          <div>
+            <div className="label">Review-first surface</div>
+            <div style={{ fontWeight: 700, marginTop: 6 }}>{order.review_focus_summary.item_summary}</div>
+            <div className="muted" style={{ marginTop: 8 }}>{order.review_focus_summary.risk_note}</div>
+          </div>
+
+          <div className="grid cols-4">
+            {reviewCues.map((cue) => (
+              <article className="card" key={cue.label}>
+                <div className="label">{cue.label}</div>
+                <div style={{ fontWeight: 700, marginTop: 6 }}>{cue.value}</div>
+                <div className="muted" style={{ marginTop: 6 }}>{cue.detail}</div>
+              </article>
+            ))}
+          </div>
+
+          {order.review_focus_summary.payment_trust_preview ? (
+            <div className="trust-cue">{order.review_focus_summary.payment_trust_preview}</div>
+          ) : null}
+
+          {order.payment_focus_summary.historical_payment_label ? (
+            <div className="card" style={{ padding: 14 }}>
+              <div className="label">Imported payment trust</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{order.payment_focus_summary.historical_payment_label}</div>
+              {order.payment_focus_summary.historical_payment_note ? (
+                <div className="muted" style={{ marginTop: 6 }}>{order.payment_focus_summary.historical_payment_note}</div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {order.review_focus_summary.missing_basics.length > 0 ? (
+            <div className="card" style={{ padding: 14 }}>
+              <div className="label">Missing basics</div>
+              <ul style={{ margin: '10px 0 0', paddingLeft: 18 }}>
+                {order.review_focus_summary.missing_basics.map((item) => (
+                  <li key={item} className="muted">{item}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          <div className="card" style={{ padding: 14 }}>
+            <div className="label">Primary blocker</div>
+            <div style={{ fontWeight: 700, marginTop: 6 }}>{primaryBlocker}</div>
+            <div className="muted" style={{ marginTop: 6 }}>{order.day_running_focus_summary.reason_summary}</div>
+          </div>
+
+          <div className="card" style={{ padding: 14 }}>
+            <div className="label">Next step</div>
+            <div style={{ fontWeight: 700, marginTop: 6 }}>{order.review_focus_summary.next_step}</div>
+            <div className="muted" style={{ marginTop: 6 }}>{order.review_focus_summary.next_step_detail}</div>
+          </div>
+        </section>
+
+        <section className="card stack">
+          <div className="label">Payment working surface</div>
+          <div className="grid cols-4">
+            <article className="card">
+              <div className="label">Amount owed now</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{formatMoney(order.payment_focus_summary.amount_owed_now ?? 0)}</div>
+              <div className="muted" style={{ marginTop: 6 }}>{describeAmountOwedNow(order.payment_focus_summary.collection_stage)}</div>
+            </article>
+            <article className="card">
+              <div className="label">Payment state</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{order.payment_focus_summary.payment_state}</div>
+              <div className="muted" style={{ marginTop: 6 }}>{order.payment_focus_summary.due_timing}</div>
+            </article>
+            <article className="card">
+              <div className="label">Deposit status</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{order.payment_focus_summary.deposit_status}</div>
+              <div className="muted" style={{ marginTop: 6 }}>Balance: {order.payment_focus_summary.balance_status}</div>
+            </article>
+            <article className="card">
+              <div className="label">Trust</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{order.payment_focus_summary.trust_label}</div>
+              <div className="muted" style={{ marginTop: 6 }}>{order.payment_focus_summary.trust_note}</div>
+            </article>
+          </div>
+
+          <div className={`trust-cue${paymentTrustTone === 'legacy_limited' ? '' : ' trust-cue-neutral'}`}>
+            {order.review_focus_summary.payment_trust_preview || `Payment trust: ${order.payment_focus_summary.trust_label}`}
+          </div>
+
+          {order.payment_focus_summary.historical_payment_label ? (
+            <div className="card" style={{ padding: 14 }}>
+              <div className="label">Historical payment</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{order.payment_focus_summary.historical_payment_label}</div>
+              {order.payment_focus_summary.historical_payment_note ? (
+                <div className="muted" style={{ marginTop: 6 }}>{order.payment_focus_summary.historical_payment_note}</div>
+              ) : null}
+            </div>
+          ) : null}
+
+          <div className="card" style={{ padding: 14 }}>
+            <div className="label">Payment risk</div>
+            <div style={{ fontWeight: 700, marginTop: 6 }}>{order.payment_focus_summary.risk_note}</div>
+            <div className="muted" style={{ marginTop: 6 }}>{order.payment_focus_summary.next_step}</div>
+            <div className="muted" style={{ marginTop: 6 }}>{order.payment_focus_summary.next_step_detail}</div>
+          </div>
+        </section>
+
+        <section className="card stack">
+          <div>
+            <div className="label">Invoice working surface</div>
+            <div style={{ fontWeight: 700, marginTop: 6 }}>{humanizeInvoiceStatus(order.invoice_focus_summary.status_label)}</div>
+            <div className="muted" style={{ marginTop: 8 }}>{order.invoice_focus_summary.readiness_note}</div>
+          </div>
+
+          <div className="grid cols-4">
+            <article className="card">
+              <div className="label">Invoice readiness</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{humanizeInvoiceStatus(order.invoice_focus_summary.status_label)}</div>
+              <div className="muted" style={{ marginTop: 6 }}>{invoiceReadinessTone === 'ready' ? 'Safe to assess for sending from the current order record.' : 'The current order record still blocks trustworthy invoice follow-up.'}</div>
+            </article>
+            <article className="card">
+              <div className="label">Order identity</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{order.invoice_focus_summary.order_identity}</div>
+              <div className="muted" style={{ marginTop: 6 }}>Invoice status: {humanizeStatus(order.invoice_summary.status)}</div>
+            </article>
+            <article className="card">
+              <div className="label">Customer identity</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{order.invoice_focus_summary.customer_identity}</div>
+              <div className="muted" style={{ marginTop: 6 }}>{order.customer_summary.email || order.customer_summary.phone || 'Customer contact detail is still limited.'}</div>
+            </article>
+            <article className="card">
+              <div className="label">Amount context</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{order.invoice_focus_summary.amount_summary}</div>
+              <div className="muted" style={{ marginTop: 6 }}>{order.invoice_focus_summary.payment_context}</div>
+            </article>
+          </div>
+
+          <div className="grid cols-4">
+            <div className="card" style={{ padding: 14 }}>
+              <div className="label">Invoice blockers</div>
+              {order.invoice_focus_summary.blockers.length > 0 ? (
+                <ul style={{ margin: '10px 0 0', paddingLeft: 18 }}>
+                  {order.invoice_focus_summary.blockers.map((item) => (
+                    <li key={item} className="muted">{item}</li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="muted" style={{ marginTop: 10 }}>No invoice blockers from the current order record.</div>
+              )}
+            </div>
+            <div className="card" style={{ padding: 14 }}>
+              <div className="label">Missing basics</div>
+              {order.invoice_focus_summary.missing_basics.length > 0 ? (
+                <ul style={{ margin: '10px 0 0', paddingLeft: 18 }}>
+                  {order.invoice_focus_summary.missing_basics.map((item) => (
+                    <li key={item} className="muted">{item}</li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="muted" style={{ marginTop: 10 }}>No extra invoice basics are missing from the current order data.</div>
+              )}
+            </div>
+            <div className="card" style={{ padding: 14, gridColumn: 'span 2' }}>
+              <div className="label">Next invoice step</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{order.invoice_focus_summary.next_step}</div>
+              <div className="muted" style={{ marginTop: 6 }}>{order.invoice_focus_summary.next_step_detail}</div>
+            </div>
+          </div>
+        </section>
+
+        <section className="card stack">
+          <div>
+            <div className="label">Handoff working surface</div>
+            <div style={{ fontWeight: 700, marginTop: 6 }}>{order.handoff_focus_summary.readiness_note}</div>
+            <div className="muted" style={{ marginTop: 8 }}>
+              Timing, method, contact, and destination clues now stay inside the Next detail route for honest handoff scan parity.
+            </div>
+          </div>
+
+          <div className="grid cols-4">
+            <article className="card">
+              <div className="label">Handoff time</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{order.handoff_focus_summary.handoff_time_label}</div>
+              <div className="muted" style={{ marginTop: 6 }}>{order.review_focus_summary.due_label}</div>
+            </article>
+            <article className="card">
+              <div className="label">Method status</div>
+              <div style={{ marginTop: 8 }}>
+                <span className={handoffMethodTone}>{order.handoff_focus_summary.method_status}</span>
+              </div>
+              <div className="muted" style={{ marginTop: 8 }}>{order.handoff_focus_summary.method_label}</div>
+            </article>
+            <article className="card">
+              <div className="label">Primary contact</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{order.handoff_focus_summary.contact_name}</div>
+              <div className="muted" style={{ marginTop: 6 }}>{order.handoff_focus_summary.primary_contact}</div>
+              {order.handoff_focus_summary.secondary_contact ? (
+                <div className="muted" style={{ marginTop: 6 }}>{order.handoff_focus_summary.secondary_contact}</div>
+              ) : null}
+            </article>
+            <article className="card">
+              <div className="label">Destination</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{order.handoff_focus_summary.destination_label}</div>
+              <div className="muted" style={{ marginTop: 6 }}>{handoffDestinationSummary}</div>
+            </article>
+          </div>
+
+          <div className="grid cols-4">
+            <div className="card" style={{ padding: 14 }}>
+              <div className="label">Contact clues</div>
+              {handoffContactLines.length > 0 ? (
+                <ul style={{ margin: '10px 0 0', paddingLeft: 18 }}>
+                  {handoffContactLines.map((item) => (
+                    <li key={item} className="muted">{item}</li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="muted" style={{ marginTop: 10 }}>No operator-safe handoff contact clues are available yet.</div>
+              )}
+            </div>
+            <div className="card" style={{ padding: 14 }}>
+              <div className="label">Missing handoff basics</div>
+              {order.handoff_focus_summary.missing_basics.length > 0 ? (
+                <ul style={{ margin: '10px 0 0', paddingLeft: 18 }}>
+                  {order.handoff_focus_summary.missing_basics.map((item) => (
+                    <li key={item} className="muted">{item}</li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="muted" style={{ marginTop: 10 }}>No extra handoff basics are missing from the current order data.</div>
+              )}
+            </div>
+            <div className="card" style={{ padding: 14, gridColumn: 'span 2' }}>
+              <div className="label">Next handoff step</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{order.handoff_focus_summary.next_step}</div>
+              <div className="muted" style={{ marginTop: 6 }}>{order.handoff_focus_summary.next_step_detail}</div>
+            </div>
+          </div>
+        </section>
+
+        {order.is_imported ? (
+          <section className="card stack">
+            <div>
+              <div className="label">Imported review</div>
+              <div style={{ fontWeight: 700, marginTop: 6 }}>{importedReviewSummary}</div>
+              <div className="muted" style={{ marginTop: 8 }}>
+                Imported source, legacy status, and bounded review reasons now stay visible inside the Next detail route for operator-safe imported triage.
+              </div>
+            </div>
+
+            <div className="grid cols-4">
+              <article className="card">
+                <div className="label">Imported from</div>
+                <div style={{ fontWeight: 700, marginTop: 6 }}>{order.import_source || 'Imported workbook'}</div>
+              </article>
+              <article className="card">
+                <div className="label">Legacy status</div>
+                <div style={{ fontWeight: 700, marginTop: 6 }}>{order.legacy_status_raw || 'Not captured'}</div>
+              </article>
+              <article className="card">
+                <div className="label">Primary review reason</div>
+                <div style={{ fontWeight: 700, marginTop: 6 }}>{describeImportReviewReason(order.primary_review_reason)}</div>
+              </article>
+              <article className="card">
+                <div className="label">Next review check</div>
+                <div style={{ fontWeight: 700, marginTop: 6 }}>{order.review_next_check || 'No current follow-up check is suggested.'}</div>
+              </article>
+            </div>
+
+            <div className="card" style={{ padding: 14 }}>
+              <div className="label">Review reasons</div>
+              {importedReviewReasons.length > 0 ? (
+                <ul style={{ margin: '10px 0 0', paddingLeft: 18 }}>
+                  {importedReviewReasons.map((item) => (
+                    <li key={item} className="muted">{item}</li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="muted" style={{ marginTop: 10 }}>No current imported-data review reasons are open for this order.</div>
+              )}
+            </div>
+          </section>
+        ) : null}
+
+        <section className="card">
+          <div className="label">Still handed off to the current app</div>
+          <div className="muted" style={{ marginTop: 8 }}>
+            Fuller order-detail parity, workflow editing, and any non-migrated operator flows remain intentionally outside BM-090. Use the current app CTA above for broader order-detail work not yet migrated.
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/frontend-next/components/order-detail-entry.tsx
+++ b/frontend-next/components/order-detail-entry.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { AuthRequiredCard } from '@/components/auth-required-card';
 import { fetchOrderDetail, type OrderDetailRecord } from '@/lib/orders';
 import { getHandoffContactLines, getHandoffDestinationSummary, getHandoffMethodTone } from '@/lib/handoff-panel';
 import { describeImportReviewReason, getImportedReviewReasons, getImportedReviewSummary } from '@/lib/imported-review-panel';
@@ -36,6 +37,17 @@ export function OrderDetailEntry({ orderId }: { orderId: string }) {
     return (
       <main className="shell">
         <section className="card muted">Loading authenticated order detail…</section>
+      </main>
+    );
+  }
+
+  if (error === 'Missing auth token') {
+    return (
+      <main className="shell">
+        <AuthRequiredCard
+          nextPath={`/orders/${orderId}`}
+          detail="Sign in first to open this authenticated order detail preview from the Next queue path."
+        />
       </main>
     );
   }

--- a/frontend-next/components/orders-queue.tsx
+++ b/frontend-next/components/orders-queue.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
+import { AuthRequiredCard } from '@/components/auth-required-card';
 import { readStoredToken } from '@/lib/auth';
 import { fetchOrdersQueue, type QueueOrder } from '@/lib/orders';
 import {
@@ -50,6 +51,15 @@ export function OrdersQueue() {
 
   const sortedOrders = useMemo(() => getSortedOrdersQueue(orders), [orders]);
   const currentAppOrderBase = getCurrentFrontendHref('/orders');
+
+  if (error === 'Missing auth token') {
+    return (
+      <AuthRequiredCard
+        nextPath="/orders"
+        detail="Sign in first to open the Next queue preview, then drill into order detail from the authenticated queue path."
+      />
+    );
+  }
 
   return (
     <div className="stack ops-layout">

--- a/frontend-next/components/orders-queue.tsx
+++ b/frontend-next/components/orders-queue.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { readStoredToken } from '@/lib/auth';
+import { fetchOrdersQueue, type QueueOrder } from '@/lib/orders';
+import {
+  formatBakeryDateTime,
+  formatMoney,
+  getActionClassMeta,
+  getCurrentFrontendHref,
+  getDayRunningPanelTone,
+  getQueueBadge,
+  getSortedOrdersQueue,
+  humanizeStatus,
+} from '@/lib/queue-ui';
+import {
+  getOpsQueuePreviewRowNextStepCue,
+  getOpsQueuePreviewRowPriorityCue,
+  getOpsQueuePreviewRowReasonCue,
+} from '@/lib/ops-preview';
+
+export function OrdersQueue() {
+  const [orders, setOrders] = useState<QueueOrder[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const token = readStoredToken();
+        if (!token) {
+          throw new Error('Missing auth token');
+        }
+
+        const nextOrders = await fetchOrdersQueue();
+        setOrders(nextOrders);
+      } catch (nextError) {
+        setError(nextError instanceof Error ? nextError.message : 'Unable to load authenticated /orders');
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    void load();
+  }, []);
+
+  const sortedOrders = useMemo(() => getSortedOrdersQueue(orders), [orders]);
+  const currentAppOrderBase = getCurrentFrontendHref('/orders');
+
+  return (
+    <div className="stack ops-layout">
+      <section className="card stack">
+        <div className="row spread start">
+          <div>
+            <div className="label">BM-085 queue to detail parity entry</div>
+            <h1 style={{ margin: '8px 0 0' }}>Orders queue</h1>
+            <p className="muted" style={{ maxWidth: 920, marginBottom: 0 }}>
+              This authenticated Next `/orders` surface now hands off into a truthful first-screen Next order-detail entry.
+              Queue ordering, compact exception framing, and imported payment trust cues stay aligned, while deeper order work
+              still remains in the current app.
+            </p>
+          </div>
+          <div className="row">
+            <Link className="button" href="/ops">
+              Back to /ops
+            </Link>
+            {currentAppOrderBase ? (
+              <a className="button" href={currentAppOrderBase}>
+                Open current app queue
+              </a>
+            ) : (
+              <button className="button" disabled title="Set NEXT_PUBLIC_CURRENT_FRONTEND_URL to wire current app queue links">
+                Open current app queue
+              </button>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {error ? <section className="card error">{error}</section> : null}
+
+      {isLoading ? <section className="card muted">Loading authenticated /orders queue…</section> : null}
+      {!isLoading && !error && sortedOrders.length === 0 ? (
+        <section className="card muted">No visible orders are currently available in the queue.</section>
+      ) : null}
+
+      <section className="stack">
+        {sortedOrders.map((order) => {
+          const queueBadge = getQueueBadge(order);
+          const actionClassMeta = getActionClassMeta(order.ops_summary.action_class);
+          const priorityCue = getOpsQueuePreviewRowPriorityCue(order.queue_summary.urgency_label);
+          const reasonCue = getOpsQueuePreviewRowReasonCue(
+            order.day_running_focus_summary.readiness_label,
+            order.day_running_focus_summary.queue_reason_preview,
+          );
+          const nextStepCue = getOpsQueuePreviewRowNextStepCue(
+            order.day_running_focus_summary.readiness_label,
+            order.day_running_focus_summary.queue_next_step_preview,
+          );
+          const currentAppDetailHref = order.ops_summary.primary_cta_path
+            ? getCurrentFrontendHref(order.ops_summary.primary_cta_path)
+            : null;
+
+          return (
+            <article className="preview-row stack" key={order.id} style={{ gap: 14 }}>
+              <div className="row spread start">
+                <div className="stack" style={{ gap: 8 }}>
+                  <div className="row" style={{ gap: 8 }}>
+                    <div style={{ fontWeight: 700 }}>{order.order_number}</div>
+                    <span className={`pill ${queueBadge.tone}`}>{queueBadge.label}</span>
+                    <span className={`pill ${actionClassMeta.tone}`}>{actionClassMeta.label}</span>
+                  </div>
+                  <div className="muted">{order.customer_summary.name || order.customer_summary.email || 'No customer'}</div>
+                  <div className="muted">Due {formatBakeryDateTime(order.due_date)} · {order.delivery_method || 'delivery TBD'}</div>
+                </div>
+                <div className="stack ops-row-side">
+                  <div style={{ fontWeight: 700 }}>{formatMoney(order.total_amount)}</div>
+                  <div className="muted ops-status-chip">{humanizeStatus(order.payment_status)}</div>
+                  <div>
+                    <span className={`pill ${priorityCue.tone}`}>{priorityCue.label}</span>
+                  </div>
+                  {reasonCue ? <div className="muted ops-microcue">{reasonCue}</div> : null}
+                  {nextStepCue ? <div className="muted ops-microcue">{nextStepCue}</div> : null}
+                </div>
+              </div>
+
+              <div className={`card tone-${getDayRunningPanelTone(order.day_running_focus_summary.readiness_label)}`}>
+                <div className="label">Day-running readiness</div>
+                <div style={{ fontWeight: 700, marginTop: 6 }}>{order.day_running_focus_summary.readiness_label}</div>
+                <div className="muted" style={{ marginTop: 6 }}>
+                  {order.day_running_focus_summary.queue_reason_preview || order.day_running_focus_summary.reason_summary}
+                </div>
+                {order.day_running_focus_summary.primary_blocker_label ? (
+                  <div className="muted" style={{ marginTop: 8, fontSize: 12, fontWeight: 600 }}>
+                    {order.day_running_focus_summary.primary_blocker_label}
+                  </div>
+                ) : null}
+                {order.day_running_focus_summary.queue_payment_trust_preview ? (
+                  <div className="trust-cue">{order.day_running_focus_summary.queue_payment_trust_preview}</div>
+                ) : null}
+              </div>
+
+              <div className="card next-action-card">
+                <div>
+                  <div className="label">Next action</div>
+                  <div style={{ fontWeight: 700, marginTop: 6 }}>{order.ops_summary.next_action}</div>
+                  <div className="muted" style={{ marginTop: 6 }}>{order.ops_summary.ops_attention}</div>
+                </div>
+                <div className="row" style={{ justifyContent: 'space-between' }}>
+                  <div className="muted" style={{ fontSize: 12 }}>
+                    BM-085 adds a truthful first-screen detail entry, while deeper order work still hands off to the current app.
+                  </div>
+                  <div className="row">
+                    <Link className="button" href={`/orders/${order.id}`}>
+                      Open detail
+                    </Link>
+                    {currentAppDetailHref && order.ops_summary.primary_cta_label ? (
+                      <a className="button primary" href={currentAppDetailHref}>
+                        {order.ops_summary.primary_cta_label} in current app
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            </article>
+          );
+        })}
+      </section>
+    </div>
+  );
+}

--- a/frontend-next/lib/auth.ts
+++ b/frontend-next/lib/auth.ts
@@ -1,0 +1,50 @@
+export const AUTH_TOKEN_STORAGE_KEY = 'token';
+export const AUTH_API_PATH = '/auth/login';
+
+export function getApiBaseUrl() {
+  return process.env.NEXT_PUBLIC_API_URL || '/api/v1';
+}
+
+export function buildLoginRequestBody(username: string, password: string) {
+  const params = new URLSearchParams();
+  params.set('username', username);
+  params.set('password', password);
+  return params.toString();
+}
+
+export type LoginResponse = {
+  access_token: string;
+  token_type: string;
+};
+
+export async function loginWithPassword(username: string, password: string): Promise<LoginResponse> {
+  const response = await fetch(`${getApiBaseUrl()}${AUTH_API_PATH}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: buildLoginRequestBody(username, password),
+  });
+
+  if (!response.ok) {
+    throw new Error('Login failed');
+  }
+
+  return response.json();
+}
+
+export function readStoredToken() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+}
+
+export function writeStoredToken(token: string) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
+}

--- a/frontend-next/lib/auth.ts
+++ b/frontend-next/lib/auth.ts
@@ -12,6 +12,16 @@ export function buildLoginRequestBody(username: string, password: string) {
   return params.toString();
 }
 
+export function buildLoginHref(nextPath = '/ops') {
+  const params = new URLSearchParams();
+  params.set('next', nextPath);
+  return `/login?${params.toString()}`;
+}
+
+export function isMissingAuthTokenError(error: unknown) {
+  return error instanceof Error && error.message === 'Missing auth token';
+}
+
 export type LoginResponse = {
   access_token: string;
   token_type: string;

--- a/frontend-next/lib/auth.ts
+++ b/frontend-next/lib/auth.ts
@@ -1,5 +1,5 @@
 export const AUTH_TOKEN_STORAGE_KEY = 'token';
-export const AUTH_API_PATH = '/auth/login';
+export const AUTH_API_PATH = '/auth/login/access-token';
 
 export function getApiBaseUrl() {
   return process.env.NEXT_PUBLIC_API_URL || '/api/v1';

--- a/frontend-next/lib/handoff-panel.ts
+++ b/frontend-next/lib/handoff-panel.ts
@@ -1,0 +1,31 @@
+import type { OrderDetailRecord } from './orders';
+
+export function getHandoffMethodTone(methodStatus: string): string {
+  switch (methodStatus) {
+    case 'Method confirmed':
+      return 'badge badge-success';
+    case 'Method needs confirmation':
+      return 'badge badge-warn';
+    default:
+      return 'badge';
+  }
+}
+
+export function getHandoffDestinationSummary(order: OrderDetailRecord): string {
+  const destination = order.handoff_focus_summary.destination_label.trim();
+  const detail = order.handoff_focus_summary.destination_detail.trim();
+
+  if (!detail || detail === destination) {
+    return destination;
+  }
+
+  return `${destination} · ${detail}`;
+}
+
+export function getHandoffContactLines(order: OrderDetailRecord): string[] {
+  return [
+    order.handoff_focus_summary.contact_name,
+    order.handoff_focus_summary.primary_contact,
+    order.handoff_focus_summary.secondary_contact,
+  ].filter((value) => value && value.trim().length > 0);
+}

--- a/frontend-next/lib/imported-review-panel.ts
+++ b/frontend-next/lib/imported-review-panel.ts
@@ -1,0 +1,32 @@
+import type { ImportedReviewReason, OrderDetailRecord } from './orders';
+
+export function describeImportReviewReason(reason?: ImportedReviewReason | null): string {
+  switch (reason) {
+    case 'overdue_payment_risk':
+      return 'Overdue payment risk';
+    case 'invoice_missing_fields':
+      return 'Invoice data needs review';
+    case 'missing_contact_details':
+      return 'Contact details missing';
+    case 'unlinked_contact':
+      return 'Customer link needs review';
+    default:
+      return 'Review needed';
+  }
+}
+
+export function getImportedReviewReasons(order: OrderDetailRecord): string[] {
+  return order.review_reasons.map((reason) => describeImportReviewReason(reason));
+}
+
+export function getImportedReviewSummary(order: OrderDetailRecord): string {
+  if (!order.is_imported) {
+    return 'This order was created in BakeMate and does not need imported-data review.';
+  }
+
+  if (!order.needs_review) {
+    return 'No current imported-data review flags are open for this order.';
+  }
+
+  return describeImportReviewReason(order.primary_review_reason);
+}

--- a/frontend-next/lib/invoice-panel.ts
+++ b/frontend-next/lib/invoice-panel.ts
@@ -1,0 +1,24 @@
+import type { OrderDetailRecord } from './orders';
+
+export function humanizeInvoiceStatus(statusLabel: string) {
+  switch (statusLabel) {
+    case 'ready_to_send':
+      return 'Ready to send';
+    case 'ready_and_paid':
+      return 'Ready and paid';
+    case 'blocked':
+      return 'Blocked';
+    default:
+      return statusLabel.replaceAll('_', ' ');
+  }
+}
+
+export function getInvoiceReadinessTone(order: OrderDetailRecord) {
+  switch (order.invoice_focus_summary.status_label) {
+    case 'ready_to_send':
+    case 'ready_and_paid':
+      return 'ready';
+    default:
+      return 'blocked';
+  }
+}

--- a/frontend-next/lib/ops-preview.ts
+++ b/frontend-next/lib/ops-preview.ts
@@ -1,0 +1,62 @@
+export function getOpsQueuePreviewPriorityLabel() {
+  return 'Highest-priority orders first.';
+}
+
+export function getOpsQueuePreviewScopeLabel(previewItemCount: number) {
+  if (previewItemCount === 1) {
+    return 'Showing 1 preview item of the full queue.';
+  }
+
+  return `Showing ${previewItemCount} preview items of the full queue.`;
+}
+
+export function getOpsQueuePreviewDrillInAffordanceLabel() {
+  return 'Open any order for details.';
+}
+
+export function getOpsQueuePreviewRowReasonCue(
+  readinessLabel: string,
+  queueReasonPreview?: string | null,
+): string | null {
+  if (readinessLabel === 'Ready for today') {
+    return null;
+  }
+
+  return queueReasonPreview ?? null;
+}
+
+export function getOpsQueuePreviewRowNextStepCue(
+  readinessLabel: string,
+  queueNextStepPreview?: string | null,
+): string | null {
+  if (readinessLabel === 'Ready for today') {
+    return null;
+  }
+
+  return queueNextStepPreview ?? null;
+}
+
+export function getOpsQueuePreviewRowPriorityCue(urgencyLabel: string) {
+  switch (urgencyLabel) {
+    case 'Urgent':
+      return {
+        label: 'Priority: Urgent',
+        tone: 'urgent',
+      };
+    case 'Today':
+      return {
+        label: 'Priority: Today',
+        tone: 'today',
+      };
+    case 'Next up':
+      return {
+        label: 'Priority: Next up',
+        tone: 'next',
+      };
+    default:
+      return {
+        label: `Priority: ${urgencyLabel}`,
+        tone: 'default',
+      };
+  }
+}

--- a/frontend-next/lib/ops.ts
+++ b/frontend-next/lib/ops.ts
@@ -1,0 +1,83 @@
+import { getApiBaseUrl, readStoredToken } from './auth';
+
+export type DayRunningSummary = {
+  all_count: number;
+  blocked_count: number;
+  needs_attention_count: number;
+  ready_count: number;
+};
+
+export type OpsPreviewOrder = {
+  id: string;
+  order_number: string;
+  status: string;
+  due_date: string;
+  payment_status: string;
+  total_amount: number;
+  delivery_method?: string | null;
+  customer_summary: {
+    name?: string | null;
+    email?: string | null;
+    phone?: string | null;
+  };
+  queue_summary: {
+    urgency_label: string;
+    urgency_rank: number;
+    is_overdue: boolean;
+    is_due_today: boolean;
+    days_until_due: number;
+  };
+  ops_summary: {
+    action_class: string;
+    next_action: string;
+    ops_attention: string;
+    primary_cta_label?: string | null;
+    primary_cta_path?: string | null;
+    primary_cta_panel?: string | null;
+  };
+  day_running_focus_summary: {
+    readiness_label: string;
+    reason_summary: string;
+    primary_blocker_label?: string | null;
+    queue_reason_preview?: string | null;
+    queue_next_step_preview?: string | null;
+    queue_payment_trust_preview?: string | null;
+  };
+};
+
+function buildAuthHeaders() {
+  const token = readStoredToken();
+  if (!token) {
+    throw new Error('Missing auth token');
+  }
+
+  return {
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+export async function fetchDayRunningSummary(): Promise<DayRunningSummary> {
+  const response = await fetch(`${getApiBaseUrl()}/orders/day-running/summary`, {
+    headers: buildAuthHeaders(),
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Unable to load day-running summary');
+  }
+
+  return response.json();
+}
+
+export async function fetchOpsPreviewOrders(): Promise<OpsPreviewOrder[]> {
+  const response = await fetch(`${getApiBaseUrl()}/orders/`, {
+    headers: buildAuthHeaders(),
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Unable to load ops preview orders');
+  }
+
+  return response.json();
+}

--- a/frontend-next/lib/orders.ts
+++ b/frontend-next/lib/orders.ts
@@ -1,0 +1,175 @@
+import { getApiBaseUrl, readStoredToken } from './auth';
+
+export type ImportedReviewReason =
+  | 'overdue_payment_risk'
+  | 'invoice_missing_fields'
+  | 'missing_contact_details'
+  | 'unlinked_contact';
+
+export type QueueOrder = {
+  id: string;
+  order_number: string;
+  status: string;
+  due_date: string;
+  payment_status: string;
+  total_amount: number;
+  delivery_method?: string | null;
+  customer_summary: {
+    contact_id?: string | null;
+    name?: string | null;
+    email?: string | null;
+    phone?: string | null;
+    is_linked_contact?: boolean;
+  };
+  queue_summary: {
+    urgency_label: string;
+    urgency_rank: number;
+    is_overdue: boolean;
+    is_due_today: boolean;
+    days_until_due: number;
+  };
+  ops_summary: {
+    action_class: string;
+    next_action: string;
+    ops_attention: string;
+    primary_cta_label?: string | null;
+    primary_cta_path?: string | null;
+    primary_cta_panel?: string | null;
+  };
+  day_running_focus_summary: {
+    readiness_label: string;
+    reason_summary: string;
+    primary_blocker_label?: string | null;
+    queue_reason_preview?: string | null;
+    queue_next_step_preview?: string | null;
+    queue_payment_trust_preview?: string | null;
+    next_step?: string;
+    supporting_items?: string[];
+  };
+};
+
+export type OrderDetailRecord = QueueOrder & {
+  is_imported: boolean;
+  import_source?: string | null;
+  legacy_status_raw?: string | null;
+  needs_review?: boolean | null;
+  review_reasons: ImportedReviewReason[];
+  primary_review_reason?: ImportedReviewReason | null;
+  review_next_check?: string | null;
+  invoice_summary: {
+    is_ready?: boolean;
+    status: string;
+    missing_fields?: string[];
+    pdf_path?: string | null;
+    client_portal_path?: string | null;
+  };
+  review_focus_summary: {
+    order_number: string;
+    customer_name: string;
+    due_label: string;
+    status_label: string;
+    item_summary: string;
+    item_count_label: string;
+    payment_confidence: string;
+    invoice_confidence: string;
+    handoff_confidence: string;
+    payment_trust_preview?: string | null;
+    missing_basics: string[];
+    risk_note: string;
+    next_step: string;
+    next_step_detail: string;
+  };
+  payment_focus_summary: {
+    amount_owed_now?: number;
+    payment_state: string;
+    collection_stage: string;
+    deposit_status: string;
+    balance_status: string;
+    due_timing: string;
+    risk_note: string;
+    next_step: string;
+    next_step_detail: string;
+    trust_state: string;
+    trust_label: string;
+    trust_note: string;
+    historical_payment_label?: string | null;
+    historical_payment_note?: string | null;
+  };
+  invoice_focus_summary: {
+    status_label: string;
+    readiness_note: string;
+    order_identity: string;
+    customer_identity: string;
+    amount_summary: string;
+    payment_context: string;
+    blockers: string[];
+    missing_basics: string[];
+    next_step: string;
+    next_step_detail: string;
+  };
+  handoff_focus_summary: {
+    handoff_time_label: string;
+    method_status: string;
+    method_label: string;
+    contact_name: string;
+    primary_contact: string;
+    secondary_contact: string;
+    destination_label: string;
+    destination_detail: string;
+    readiness_note: string;
+    missing_basics: string[];
+    next_step: string;
+    next_step_detail: string;
+  };
+  production_focus_summary: {
+    readiness_label: string;
+    missing_basics: string[];
+    attention_note: string;
+    next_step: string;
+    next_step_detail: string;
+  };
+  contact_focus_summary: {
+    readiness_label: string;
+    missing_basics: string[];
+    attention_note: string;
+    next_step: string;
+    next_step_detail: string;
+  };
+};
+
+function buildAuthHeaders() {
+  const token = readStoredToken();
+  if (!token) {
+    throw new Error('Missing auth token');
+  }
+
+  return {
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+export async function fetchOrdersQueue(): Promise<QueueOrder[]> {
+  const response = await fetch(`${getApiBaseUrl()}/orders/`, {
+    headers: buildAuthHeaders(),
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Unable to load orders queue');
+  }
+
+  return response.json();
+}
+
+export async function fetchOrderDetail(orderId: string): Promise<OrderDetailRecord> {
+  const response = await fetch(`${getApiBaseUrl()}/orders/${orderId}`, {
+    headers: buildAuthHeaders(),
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Unable to load order detail');
+  }
+
+  return response.json();
+}

--- a/frontend-next/lib/payment-panel.ts
+++ b/frontend-next/lib/payment-panel.ts
@@ -1,0 +1,20 @@
+import type { OrderDetailRecord } from './orders';
+
+export function describeAmountOwedNow(collectionStage: string) {
+  switch (collectionStage) {
+    case 'deposit_due':
+    case 'deposit_overdue':
+      return 'Amount owed now reflects the deposit currently due.';
+    case 'balance_due':
+    case 'balance_overdue':
+      return 'Amount owed now reflects the final balance currently due.';
+    case 'paid_in_full':
+      return 'No payment is currently due.';
+    default:
+      return 'Amount owed now reflects the current payment checkpoint.';
+  }
+}
+
+export function getPaymentTrustTone(order: OrderDetailRecord) {
+  return order.payment_focus_summary.trust_state === 'legacy_limited' ? 'legacy_limited' : 'trusted';
+}

--- a/frontend-next/lib/preview-validation.ts
+++ b/frontend-next/lib/preview-validation.ts
@@ -1,0 +1,59 @@
+export const PREVIEW_VALIDATION_FEEDBACK_SUBJECT = 'BakeMate Next preview mismatch';
+
+export const PREVIEW_VALIDATION_FEEDBACK_PROMPT =
+  'Report the route tested, what differed from React/Vite, expected behavior, actual behavior, and any order number involved.';
+
+export const PREVIEW_VALIDATION_TEST_PATH = [
+  'Landing page',
+  'Login',
+  'Authenticated /ops',
+  'Orders queue',
+  'Order detail',
+] as const;
+
+export type PreviewValidationCheck = {
+  label: string;
+  detail: string;
+  state: 'accepted' | 'bounded' | 'handoff';
+};
+
+export const PREVIEW_VALIDATION_CHECKS: PreviewValidationCheck[] = [
+  {
+    label: 'BM-093 path accepted',
+    detail: 'Landing page -> login -> /ops -> /orders -> order detail remains the Next preview path to validate.',
+    state: 'accepted',
+  },
+  {
+    label: 'Read-only preview scope',
+    detail: 'The Next surface validates navigation, queue readout, and order-detail entry only.',
+    state: 'bounded',
+  },
+  {
+    label: 'React/Vite remains trusted',
+    detail: 'Use the current React/Vite app for live operations and deeper order work.',
+    state: 'handoff',
+  },
+];
+
+export function getPreviewValidationPathLabel() {
+  return PREVIEW_VALIDATION_TEST_PATH.join(' -> ');
+}
+
+export function getPreviewValidationFeedbackHref() {
+  const subject = encodeURIComponent(PREVIEW_VALIDATION_FEEDBACK_SUBJECT);
+  const body = encodeURIComponent(PREVIEW_VALIDATION_FEEDBACK_PROMPT);
+
+  return `mailto:?subject=${subject}&body=${body}`;
+}
+
+export function getPreviewValidationStateLabel(state: PreviewValidationCheck['state']) {
+  if (state === 'accepted') {
+    return 'Accepted';
+  }
+
+  if (state === 'handoff') {
+    return 'Truth boundary';
+  }
+
+  return 'Preview only';
+}

--- a/frontend-next/lib/queue-ui.ts
+++ b/frontend-next/lib/queue-ui.ts
@@ -1,0 +1,88 @@
+import type { QueueOrder } from './orders';
+
+export function formatMoney(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(value);
+}
+
+export function formatBakeryDateTime(value: string) {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  }).format(parsed);
+}
+
+export function humanizeStatus(value: string) {
+  return value.split('_').join(' ');
+}
+
+export function getQueueBadge(order: QueueOrder) {
+  if (order.queue_summary.is_overdue) {
+    return { label: 'Overdue', tone: 'danger' };
+  }
+
+  if (order.queue_summary.is_due_today) {
+    return { label: 'Due today', tone: 'warn' };
+  }
+
+  if (order.queue_summary.days_until_due <= 3) {
+    return { label: 'Next up', tone: 'info' };
+  }
+
+  return { label: 'Upcoming', tone: 'neutral' };
+}
+
+export function getActionClassMeta(actionClass: string) {
+  switch (actionClass) {
+    case 'payment_now':
+      return { label: 'Payment now', tone: 'danger' };
+    case 'invoice_blocked':
+      return { label: 'Invoice blocked', tone: 'violet' };
+    case 'handoff_today':
+      return { label: 'Handoff today', tone: 'warn' };
+    default:
+      return { label: 'Watch', tone: 'neutral' };
+  }
+}
+
+export function getDayRunningPanelTone(readinessLabel: string) {
+  switch (readinessLabel) {
+    case 'Ready for today':
+      return 'success';
+    case 'Needs attention today':
+      return 'warn';
+    default:
+      return 'danger';
+  }
+}
+
+export function getSortedOrdersQueue(orders: QueueOrder[]) {
+  return [...orders].sort((left, right) => {
+    const urgencyDelta = left.queue_summary.urgency_rank - right.queue_summary.urgency_rank;
+    if (urgencyDelta !== 0) {
+      return urgencyDelta;
+    }
+
+    return new Date(left.due_date).getTime() - new Date(right.due_date).getTime();
+  });
+}
+
+export function getCurrentFrontendHref(path: string) {
+  const baseUrl = process.env.NEXT_PUBLIC_CURRENT_FRONTEND_URL;
+  if (!baseUrl) {
+    return null;
+  }
+
+  return `${baseUrl.replace(/\/$/, '')}${path}`;
+}

--- a/frontend-next/lib/review-panel.ts
+++ b/frontend-next/lib/review-panel.ts
@@ -1,0 +1,30 @@
+import type { OrderDetailRecord } from './orders';
+
+export function getReviewPrimaryBlocker(order: OrderDetailRecord) {
+  return order.day_running_focus_summary.primary_blocker_label || order.day_running_focus_summary.reason_summary;
+}
+
+export function getReviewCueRows(order: OrderDetailRecord) {
+  return [
+    {
+      label: 'Day-running readiness',
+      value: order.day_running_focus_summary.readiness_label,
+      detail: order.day_running_focus_summary.reason_summary,
+    },
+    {
+      label: 'Production',
+      value: order.production_focus_summary.readiness_label,
+      detail: order.production_focus_summary.attention_note,
+    },
+    {
+      label: 'Contact',
+      value: order.contact_focus_summary.readiness_label,
+      detail: order.contact_focus_summary.attention_note,
+    },
+    {
+      label: 'Payment trust',
+      value: order.review_focus_summary.payment_trust_preview || order.payment_focus_summary.trust_label,
+      detail: order.payment_focus_summary.trust_note,
+    },
+  ];
+}

--- a/frontend-next/next-env.d.ts
+++ b/frontend-next/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend-next/next.config.ts
+++ b/frontend-next/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/frontend-next/package-lock.json
+++ b/frontend-next/package-lock.json
@@ -1,0 +1,943 @@
+{
+  "name": "frontend-next",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frontend-next",
+      "version": "0.1.0",
+      "dependencies": {
+        "next": "15.2.4",
+        "react": "19.0.0",
+        "react-dom": "19.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.14.0",
+        "@types/react": "^19.0.10",
+        "@types/react-dom": "^19.0.4",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.4.tgz",
+      "integrity": "sha512-+SFtMgoiYP3WoSswuNmxJOCwi06TdWE733D+WPjpXIe4LXGULwEaofiiAy6kbS0+XjM5xF5n3lKuBwN2SnqD9g==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.4.tgz",
+      "integrity": "sha512-1AnMfs655ipJEDC/FHkSr0r3lXBgpqKo4K1kiwfUf3iE68rDFXZ1TtHdMvf7D0hMItgDZ7Vuq3JgNMbt/+3bYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.4.tgz",
+      "integrity": "sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.4.tgz",
+      "integrity": "sha512-HFN6GKUcrTWvem8AZN7tT95zPb0GUGv9v0d0iyuTb303vbXkkbHDp/DxufB04jNVD+IN9yHy7y/6Mqq0h0YVaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.4.tgz",
+      "integrity": "sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.4.tgz",
+      "integrity": "sha512-yb5WTRaHdkgOqFOZiu6rHV1fAEK0flVpaIN2HB6kxHVSy/dIajWbThS7qON3W9/SNOH2JWkVCyulgGYekMePuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.4.tgz",
+      "integrity": "sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.4.tgz",
+      "integrity": "sha512-dW0i7eukvDxtIhCYkMrZNQfNicPDExt2jPb9AZPpL7cfyUo7QSNl1DjsHjmmKp6qNAqUESyT8YFl/Aw91cNJJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.4.tgz",
+      "integrity": "sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.2.4.tgz",
+      "integrity": "sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.2.4",
+        "@swc/counter": "0.1.3",
+        "@swc/helpers": "0.5.15",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.2.4",
+        "@next/swc-darwin-x64": "15.2.4",
+        "@next/swc-linux-arm64-gnu": "15.2.4",
+        "@next/swc-linux-arm64-musl": "15.2.4",
+        "@next/swc-linux-x64-gnu": "15.2.4",
+        "@next/swc-linux-x64-musl": "15.2.4",
+        "@next/swc-win32-arm64-msvc": "15.2.4",
+        "@next/swc-win32-x64-msvc": "15.2.4",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/frontend-next/package.json
+++ b/frontend-next/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "frontend-next",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "node --experimental-strip-types --test tests/*.test.mjs"
+  },
+  "dependencies": {
+    "next": "15.2.4",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.0",
+    "@types/react": "^19.0.10",
+    "@types/react-dom": "^19.0.4",
+    "typescript": "^5.8.3"
+  }
+}

--- a/frontend-next/tests/auth-compat.test.mjs
+++ b/frontend-next/tests/auth-compat.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { AUTH_API_PATH, AUTH_TOKEN_STORAGE_KEY, buildLoginRequestBody } from '../lib/auth.ts';
+import { AUTH_API_PATH, AUTH_TOKEN_STORAGE_KEY, buildLoginHref, buildLoginRequestBody, isMissingAuthTokenError } from '../lib/auth.ts';
 
 test('next scaffold keeps the current auth token storage key', () => {
   assert.equal(AUTH_TOKEN_STORAGE_KEY, 'token');
@@ -12,4 +12,13 @@ test('next scaffold keeps the current auth login path', () => {
 
 test('next scaffold uses form-encoded credentials', () => {
   assert.equal(buildLoginRequestBody('admin@example.com', 'password'), 'username=admin%40example.com&password=password');
+});
+
+test('next preview login can hand off into a requested authenticated route', () => {
+  assert.equal(buildLoginHref('/orders/abc123'), '/login?next=%2Forders%2Fabc123');
+});
+
+test('next preview recognizes the current missing-token auth boundary', () => {
+  assert.equal(isMissingAuthTokenError(new Error('Missing auth token')), true);
+  assert.equal(isMissingAuthTokenError(new Error('Login failed')), false);
 });

--- a/frontend-next/tests/auth-compat.test.mjs
+++ b/frontend-next/tests/auth-compat.test.mjs
@@ -6,8 +6,8 @@ test('next scaffold keeps the current auth token storage key', () => {
   assert.equal(AUTH_TOKEN_STORAGE_KEY, 'token');
 });
 
-test('next scaffold keeps the current auth login path', () => {
-  assert.equal(AUTH_API_PATH, '/auth/login');
+test('next scaffold keeps the current auth token endpoint path', () => {
+  assert.equal(AUTH_API_PATH, '/auth/login/access-token');
 });
 
 test('next scaffold uses form-encoded credentials', () => {

--- a/frontend-next/tests/auth-compat.test.mjs
+++ b/frontend-next/tests/auth-compat.test.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { AUTH_API_PATH, AUTH_TOKEN_STORAGE_KEY, buildLoginRequestBody } from '../lib/auth.ts';
+
+test('next scaffold keeps the current auth token storage key', () => {
+  assert.equal(AUTH_TOKEN_STORAGE_KEY, 'token');
+});
+
+test('next scaffold keeps the current auth login path', () => {
+  assert.equal(AUTH_API_PATH, '/auth/login');
+});
+
+test('next scaffold uses form-encoded credentials', () => {
+  assert.equal(buildLoginRequestBody('admin@example.com', 'password'), 'username=admin%40example.com&password=password');
+});

--- a/frontend-next/tests/handoff-panel.test.mjs
+++ b/frontend-next/tests/handoff-panel.test.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  getHandoffContactLines,
+  getHandoffDestinationSummary,
+  getHandoffMethodTone,
+} from '../lib/handoff-panel.ts';
+
+const order = {
+  handoff_focus_summary: {
+    contact_name: 'Jordan Lee',
+    primary_contact: '(555) 010-4444',
+    secondary_contact: 'jordan@example.com',
+    destination_label: '123 Main St',
+    destination_detail: 'Suite 4',
+  },
+};
+
+test('getHandoffMethodTone highlights confirmed handoff method', () => {
+  assert.equal(getHandoffMethodTone('Method confirmed'), 'badge badge-success');
+});
+
+test('getHandoffMethodTone highlights handoff methods needing confirmation', () => {
+  assert.equal(getHandoffMethodTone('Method needs confirmation'), 'badge badge-warn');
+});
+
+test('getHandoffDestinationSummary keeps destination detail compact when it adds value', () => {
+  assert.equal(getHandoffDestinationSummary(order), '123 Main St · Suite 4');
+});
+
+test('getHandoffContactLines returns only available operator contact clues', () => {
+  assert.deepEqual(getHandoffContactLines(order), ['Jordan Lee', '(555) 010-4444', 'jordan@example.com']);
+});

--- a/frontend-next/tests/imported-review-panel.test.mjs
+++ b/frontend-next/tests/imported-review-panel.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  describeImportReviewReason,
+  getImportedReviewReasons,
+  getImportedReviewSummary,
+} from '../lib/imported-review-panel.ts';
+
+test('describeImportReviewReason preserves accepted imported-review wording', () => {
+  assert.equal(describeImportReviewReason('invoice_missing_fields'), 'Invoice data needs review');
+  assert.equal(describeImportReviewReason('missing_contact_details'), 'Contact details missing');
+});
+
+test('getImportedReviewReasons maps all imported-review reasons into operator-safe labels', () => {
+  assert.deepEqual(
+    getImportedReviewReasons({
+      review_reasons: ['overdue_payment_risk', 'unlinked_contact'],
+    }),
+    ['Overdue payment risk', 'Customer link needs review'],
+  );
+});
+
+test('getImportedReviewSummary stays quiet for native BakeMate orders', () => {
+  assert.equal(
+    getImportedReviewSummary({ is_imported: false, needs_review: false, primary_review_reason: null }),
+    'This order was created in BakeMate and does not need imported-data review.',
+  );
+});
+
+test('getImportedReviewSummary uses the accepted primary imported-review reason when review is needed', () => {
+  assert.equal(
+    getImportedReviewSummary({
+      is_imported: true,
+      needs_review: true,
+      primary_review_reason: 'overdue_payment_risk',
+    }),
+    'Overdue payment risk',
+  );
+});

--- a/frontend-next/tests/invoice-panel.test.mjs
+++ b/frontend-next/tests/invoice-panel.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getInvoiceReadinessTone, humanizeInvoiceStatus } from '../lib/invoice-panel.ts';
+
+test('bm-088 invoice panel humanizes ready-to-send status', () => {
+  assert.equal(humanizeInvoiceStatus('ready_to_send'), 'Ready to send');
+});
+
+test('bm-088 invoice panel keeps ready tone for invoice-safe states', () => {
+  assert.equal(
+    getInvoiceReadinessTone({ invoice_focus_summary: { status_label: 'ready_and_paid' } }),
+    'ready',
+  );
+});
+
+test('bm-088 invoice panel keeps blocked tone when invoice work is not ready', () => {
+  assert.equal(
+    getInvoiceReadinessTone({ invoice_focus_summary: { status_label: 'blocked' } }),
+    'blocked',
+  );
+});

--- a/frontend-next/tests/ops-preview.test.mjs
+++ b/frontend-next/tests/ops-preview.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getOpsQueuePreviewDrillInAffordanceLabel,
+  getOpsQueuePreviewPriorityLabel,
+  getOpsQueuePreviewRowNextStepCue,
+  getOpsQueuePreviewRowPriorityCue,
+  getOpsQueuePreviewRowReasonCue,
+  getOpsQueuePreviewScopeLabel,
+} from '../lib/ops-preview.ts';
+
+test('next ops preview keeps the accepted priority label', () => {
+  assert.equal(getOpsQueuePreviewPriorityLabel(), 'Highest-priority orders first.');
+});
+
+test('next ops preview keeps the accepted drill-in affordance label', () => {
+  assert.equal(getOpsQueuePreviewDrillInAffordanceLabel(), 'Open any order for details.');
+});
+
+test('next ops preview keeps explicit preview scope labeling', () => {
+  assert.equal(getOpsQueuePreviewScopeLabel(3), 'Showing 3 preview items of the full queue.');
+});
+
+test('next ops preview reason cue stays exception-only', () => {
+  assert.equal(getOpsQueuePreviewRowReasonCue('Blocked for today', 'Attention: Deposit due'), 'Attention: Deposit due');
+  assert.equal(getOpsQueuePreviewRowReasonCue('Ready for today', 'Attention: Review order'), null);
+});
+
+test('next ops preview next-step cue stays exception-only', () => {
+  assert.equal(getOpsQueuePreviewRowNextStepCue('Needs attention today', 'Next: collect deposit'), 'Next: collect deposit');
+  assert.equal(getOpsQueuePreviewRowNextStepCue('Ready for today', 'Next: review order'), null);
+});
+
+test('next ops preview priority cue keeps urgent wording', () => {
+  assert.deepEqual(getOpsQueuePreviewRowPriorityCue('Urgent'), { label: 'Priority: Urgent', tone: 'urgent' });
+});

--- a/frontend-next/tests/order-detail-entry.test.mjs
+++ b/frontend-next/tests/order-detail-entry.test.mjs
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getCurrentFrontendHref } from '../lib/queue-ui.ts';
+
+test('bm-085 current-app handoff helper returns null when current frontend base is unset', () => {
+  const previous = process.env.NEXT_PUBLIC_CURRENT_FRONTEND_URL;
+  delete process.env.NEXT_PUBLIC_CURRENT_FRONTEND_URL;
+  assert.equal(getCurrentFrontendHref('/orders/abc123'), null);
+  if (previous === undefined) {
+    delete process.env.NEXT_PUBLIC_CURRENT_FRONTEND_URL;
+  } else {
+    process.env.NEXT_PUBLIC_CURRENT_FRONTEND_URL = previous;
+  }
+});
+
+test('bm-085 current-app handoff helper builds a stable current-app order detail URL', () => {
+  const previous = process.env.NEXT_PUBLIC_CURRENT_FRONTEND_URL;
+  process.env.NEXT_PUBLIC_CURRENT_FRONTEND_URL = 'http://localhost:5174/';
+  assert.equal(getCurrentFrontendHref('/orders/abc123'), 'http://localhost:5174/orders/abc123');
+  if (previous === undefined) {
+    delete process.env.NEXT_PUBLIC_CURRENT_FRONTEND_URL;
+  } else {
+    process.env.NEXT_PUBLIC_CURRENT_FRONTEND_URL = previous;
+  }
+});

--- a/frontend-next/tests/orders-queue.test.mjs
+++ b/frontend-next/tests/orders-queue.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getSortedOrdersQueue } from '../lib/queue-ui.ts';
+
+test('next orders queue preserves accepted urgency-first ordering', () => {
+  const orders = [
+    {
+      id: 'later-urgent',
+      due_date: '2026-04-10T15:00:00Z',
+      queue_summary: { urgency_rank: 1 },
+    },
+    {
+      id: 'earlier-urgent',
+      due_date: '2026-04-09T15:00:00Z',
+      queue_summary: { urgency_rank: 1 },
+    },
+    {
+      id: 'next-rank',
+      due_date: '2026-04-08T15:00:00Z',
+      queue_summary: { urgency_rank: 2 },
+    },
+  ];
+
+  const sorted = getSortedOrdersQueue(orders);
+  assert.deepEqual(
+    sorted.map((order) => order.id),
+    ['earlier-urgent', 'later-urgent', 'next-rank'],
+  );
+});

--- a/frontend-next/tests/payment-panel.test.mjs
+++ b/frontend-next/tests/payment-panel.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { describeAmountOwedNow, getPaymentTrustTone } from '../lib/payment-panel.ts';
+
+test('bm-087 payment panel explains deposit-stage amount owed now', () => {
+  assert.equal(describeAmountOwedNow('deposit_due'), 'Amount owed now reflects the deposit currently due.');
+});
+
+test('bm-087 payment panel explains final-balance-stage amount owed now', () => {
+  assert.equal(describeAmountOwedNow('balance_due'), 'Amount owed now reflects the final balance currently due.');
+});
+
+test('bm-087 payment panel preserves legacy-limited trust tone', () => {
+  assert.equal(
+    getPaymentTrustTone({ payment_focus_summary: { trust_state: 'legacy_limited' } }),
+    'legacy_limited',
+  );
+});

--- a/frontend-next/tests/preview-validation.test.mjs
+++ b/frontend-next/tests/preview-validation.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PREVIEW_VALIDATION_CHECKS,
+  PREVIEW_VALIDATION_FEEDBACK_PROMPT,
+  getPreviewValidationFeedbackHref,
+  getPreviewValidationPathLabel,
+  getPreviewValidationStateLabel,
+} from '../lib/preview-validation.ts';
+
+test('bm-094 exposes the accepted bm-093 test path', () => {
+  assert.equal(
+    getPreviewValidationPathLabel(),
+    'Landing page -> Login -> Authenticated /ops -> Orders queue -> Order detail',
+  );
+});
+
+test('bm-094 keeps the React/Vite truth boundary explicit', () => {
+  assert.ok(
+    PREVIEW_VALIDATION_CHECKS.some((check) => (
+      check.state === 'handoff' && check.detail.includes('React/Vite')
+    )),
+  );
+});
+
+test('bm-094 does not widen the checklist beyond the preview surface', () => {
+  assert.deepEqual(
+    PREVIEW_VALIDATION_CHECKS.map((check) => check.state),
+    ['accepted', 'bounded', 'handoff'],
+  );
+});
+
+test('bm-094 feedback affordance is concrete without a write workflow', () => {
+  assert.ok(getPreviewValidationFeedbackHref().startsWith('mailto:?subject=BakeMate%20Next%20preview%20mismatch'));
+  assert.match(PREVIEW_VALIDATION_FEEDBACK_PROMPT, /route tested/);
+  assert.equal(getPreviewValidationStateLabel('bounded'), 'Preview only');
+});

--- a/frontend-next/tests/review-panel.test.mjs
+++ b/frontend-next/tests/review-panel.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getReviewCueRows, getReviewPrimaryBlocker } from '../lib/review-panel.ts';
+
+const sampleOrder = {
+  day_running_focus_summary: {
+    readiness_label: 'Blocked for today',
+    reason_summary: 'Attention: Deposit due',
+    primary_blocker_label: 'Deposit due before production',
+  },
+  production_focus_summary: {
+    readiness_label: 'Needs clarification',
+    attention_note: 'Production basics still need review',
+  },
+  contact_focus_summary: {
+    readiness_label: 'Ready to contact',
+    attention_note: 'Best contact method is available',
+  },
+  review_focus_summary: {
+    payment_trust_preview: 'Payment trust: legacy-limited',
+  },
+  payment_focus_summary: {
+    trust_label: 'Legacy-limited',
+    trust_note: 'Historical payment certainty is limited for imported data.',
+  },
+};
+
+test('bm-086 review panel keeps the explicit primary blocker when present', () => {
+  assert.equal(getReviewPrimaryBlocker(sampleOrder), 'Deposit due before production');
+});
+
+test('bm-086 review panel falls back to reason summary when no explicit blocker exists', () => {
+  assert.equal(
+    getReviewPrimaryBlocker({
+      ...sampleOrder,
+      day_running_focus_summary: {
+        ...sampleOrder.day_running_focus_summary,
+        primary_blocker_label: '',
+      },
+    }),
+    'Attention: Deposit due',
+  );
+});
+
+test('bm-086 review panel preserves accepted readiness and trust cues', () => {
+  assert.deepEqual(getReviewCueRows(sampleOrder), [
+    {
+      label: 'Day-running readiness',
+      value: 'Blocked for today',
+      detail: 'Attention: Deposit due',
+    },
+    {
+      label: 'Production',
+      value: 'Needs clarification',
+      detail: 'Production basics still need review',
+    },
+    {
+      label: 'Contact',
+      value: 'Ready to contact',
+      detail: 'Best contact method is available',
+    },
+    {
+      label: 'Payment trust',
+      value: 'Payment trust: legacy-limited',
+      detail: 'Historical payment certainty is limited for imported data.',
+    },
+  ]);
+});

--- a/frontend-next/tsconfig.json
+++ b/frontend-next/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import Ingredients from './pages/Ingredients';
 import Orders from './pages/Orders';
 import OrderDetail from './pages/OrderDetail';
 import ImportedRecords from './pages/ImportedRecords';
+import OpsHome from './pages/OpsHome';
 
 export default function App() {
   return (
@@ -21,10 +22,11 @@ export default function App() {
               <Route path="dashboard" element={<Dashboard />} />
               <Route path="recipes" element={<Recipes />} />
               <Route path="ingredients" element={<Ingredients />} />
+              <Route path="ops" element={<OpsHome />} />
               <Route path="orders" element={<Orders />} />
               <Route path="orders/imported" element={<ImportedRecords />} />
               <Route path="orders/:orderId" element={<OrderDetail />} />
-              <Route index element={<Navigate to="/dashboard" replace />} />
+              <Route index element={<Navigate to="/ops" replace />} />
             </Route>
           </Route>
         </Routes>

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -111,6 +111,11 @@ export interface OrderRecord {
     risk_note: string;
     next_step: string;
     next_step_detail: string;
+    trust_state: string;
+    trust_label: string;
+    trust_note: string;
+    historical_payment_label?: string | null;
+    historical_payment_note?: string | null;
   };
   handoff_focus_summary: {
     handoff_time_label: string;
@@ -136,6 +141,7 @@ export interface OrderRecord {
     payment_confidence: string;
     invoice_confidence: string;
     handoff_confidence: string;
+    payment_trust_preview?: string | null;
     missing_basics: string[];
     risk_note: string;
     next_step: string;
@@ -166,6 +172,7 @@ export interface OrderRecord {
     primary_blocker_label: string;
     queue_reason_preview?: string | null;
     queue_next_step_preview?: string | null;
+    queue_payment_trust_preview?: string | null;
     queue_contact_preview?: string | null;
     queue_payment_preview?: string | null;
     queue_handoff_preview?: string | null;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -10,6 +10,7 @@ export default function DashboardLayout() {
       <div className="w-64 bg-gray-800 text-white flex flex-col">
         <div className="px-8 py-4 text-2xl font-bold">BakeMate</div>
         <nav className="flex-grow">
+          <Link to="/ops" className="block px-8 py-3 text-sm hover:bg-gray-700">Ops Home</Link>
           <Link to="/dashboard" className="block px-8 py-3 text-sm hover:bg-gray-700">Dashboard</Link>
           <Link to="/recipes" className="block px-8 py-3 text-sm hover:bg-gray-700">Recipes</Link>
           <Link to="/ingredients" className="block px-8 py-3 text-sm hover:bg-gray-700">Ingredients</Link>

--- a/frontend/src/pages/OpsHome.tsx
+++ b/frontend/src/pages/OpsHome.tsx
@@ -1,0 +1,561 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+import { Link } from 'react-router-dom';
+
+import { ordersApi } from '../api';
+import type { DayRunningQueueSummary, DayRunningTriageFilter, OrderRecord } from '../api';
+import { formatBakeryDateTime } from '../utils/dateTime';
+import {
+  dismissGuardedOpsRetryFeedback,
+  getGuardedOpsRetryFeedback,
+  getGuardedOpsRetryUiState,
+} from './opsHomeRetryState';
+import { getOpsQueuePreviewDrillInAffordanceLabel } from './opsQueuePreviewDrillInAffordance';
+import { getOpsQueuePreviewPriorityLabel } from './opsQueuePreviewPriority';
+import { getOpsQueuePreviewRowNextStepCue } from './opsQueuePreviewRowNextStepCue';
+import { getOpsQueuePreviewRowPriorityCue } from './opsQueuePreviewRowPriorityCue';
+import { getOpsQueuePreviewRowReasonCue } from './opsQueuePreviewRowReasonCue';
+import { getOpsQueuePreviewScopeLabel } from './opsQueuePreviewScope';
+
+function formatMoney(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(value);
+}
+
+function humanizeStatus(value: string) {
+  return value.split('_').join(' ');
+}
+
+function getQueueBadge(order: OrderRecord) {
+  if (order.queue_summary.is_overdue) {
+    return {
+      label: 'Overdue',
+      className: 'bg-rose-100 text-rose-700',
+    };
+  }
+  if (order.queue_summary.is_due_today) {
+    return {
+      label: 'Due today',
+      className: 'bg-amber-100 text-amber-800',
+    };
+  }
+  if (order.queue_summary.days_until_due <= 3) {
+    return {
+      label: 'Next up',
+      className: 'bg-sky-100 text-sky-800',
+    };
+  }
+  return {
+    label: 'Upcoming',
+    className: 'bg-slate-100 text-slate-700',
+  };
+}
+
+function getActionClassMeta(actionClass: string) {
+  switch (actionClass) {
+    case 'payment_now':
+      return {
+        label: 'Payment now',
+        className: 'bg-rose-100 text-rose-700',
+        ctaClassName: 'bg-rose-600 text-white hover:bg-rose-700',
+      };
+    case 'invoice_blocked':
+      return {
+        label: 'Invoice blocked',
+        className: 'bg-violet-100 text-violet-700',
+        ctaClassName: 'bg-violet-600 text-white hover:bg-violet-700',
+      };
+    case 'handoff_today':
+      return {
+        label: 'Handoff today',
+        className: 'bg-amber-100 text-amber-800',
+        ctaClassName: 'bg-amber-500 text-slate-950 hover:bg-amber-400',
+      };
+    default:
+      return {
+        label: 'Watch',
+        className: 'bg-slate-100 text-slate-700',
+        ctaClassName: 'bg-slate-900 text-white hover:bg-slate-700',
+      };
+  }
+}
+
+function getDayRunningMeta(readinessLabel: string) {
+  switch (readinessLabel) {
+    case 'Ready for today':
+      return 'border-emerald-200 bg-emerald-50 text-emerald-700';
+    case 'Needs attention today':
+      return 'border-amber-200 bg-amber-50 text-amber-700';
+    default:
+      return 'border-rose-200 bg-rose-50 text-rose-700';
+  }
+}
+
+function getSummaryCardTone(kind: 'blocked' | 'needs_attention' | 'ready' | 'all') {
+  switch (kind) {
+    case 'blocked':
+      return 'border-rose-200 bg-rose-50 text-rose-700';
+    case 'needs_attention':
+      return 'border-amber-200 bg-amber-50 text-amber-700';
+    case 'ready':
+      return 'border-emerald-200 bg-emerald-50 text-emerald-700';
+    default:
+      return 'border-slate-200 bg-slate-50 text-slate-700';
+  }
+}
+
+function getDayRunningCount(summary: DayRunningQueueSummary | null, filter: 'all' | DayRunningTriageFilter) {
+  if (!summary) {
+    return 0;
+  }
+
+  switch (filter) {
+    case 'blocked':
+      return summary.blocked_count;
+    case 'needs_attention':
+      return summary.needs_attention_count;
+    case 'ready':
+      return summary.ready_count;
+    default:
+      return summary.all_count;
+  }
+}
+
+function getAttentionHeadline(summary: DayRunningQueueSummary | null) {
+  if (!summary) {
+    return 'Loading today’s ops view…';
+  }
+  if (summary.blocked_count > 0) {
+    return `${summary.blocked_count} blocked ${summary.blocked_count === 1 ? 'order needs' : 'orders need'} help first.`;
+  }
+  if (summary.needs_attention_count > 0) {
+    return `${summary.needs_attention_count} ${summary.needs_attention_count === 1 ? 'order needs' : 'orders need'} attention next.`;
+  }
+  if (summary.ready_count > 0) {
+    return `${summary.ready_count} ${summary.ready_count === 1 ? 'order is' : 'orders are'} ready to work now.`;
+  }
+  return 'No day-running work is currently visible in this preview.';
+}
+
+function getTopAttentionOrders(orders: OrderRecord[]) {
+  return [...orders]
+    .sort((left, right) => {
+      const urgencyDelta = left.queue_summary.urgency_rank - right.queue_summary.urgency_rank;
+      if (urgencyDelta !== 0) {
+        return urgencyDelta;
+      }
+      return new Date(left.due_date).getTime() - new Date(right.due_date).getTime();
+    })
+    .slice(0, 6);
+}
+
+type OpsHomeReadinessState = {
+  title: string;
+  message: string;
+  note: string;
+  action: string;
+  recoveryCommandLabel: string;
+  recoveryCommand: string;
+  guidanceTitle: string;
+  guidanceSource: string;
+  guidanceSteps: string[];
+};
+
+type OpsHomeRetryFeedback = {
+  tone: 'warning' | 'success';
+  checkedLabel: string;
+  message: string;
+  dismissLabel?: string;
+};
+
+function getReadinessState(error: unknown): OpsHomeReadinessState | null {
+  if (!axios.isAxiosError(error)) {
+    return null;
+  }
+
+  const detail = error.response?.data?.detail;
+  if (!detail || detail.code !== 'local_dev_schema_stale') {
+    return null;
+  }
+
+  return {
+    title: detail.title || 'Local dev setup needs refresh',
+    message:
+      detail.message || 'Local dev data needs a schema refresh before Ops Home can load live queue data.',
+    note: detail.note || 'This is a local BakeMate setup issue, not a bakery workflow status.',
+    action: detail.action || 'Refresh or reseed the local dev database, then reload /ops.',
+    recoveryCommandLabel: detail.recovery_command_label || 'Run locally from the BakeMate repo',
+    recoveryCommand: detail.recovery_command || 'docker compose up --build -d',
+    guidanceTitle: detail.guidance_title || 'How to recover locally',
+    guidanceSource: detail.guidance_source || 'README.md and docs/developer_guide.md',
+    guidanceSteps: detail.guidance_steps || [
+      'Use the normal BakeMate local setup flow from README.md or docs/developer_guide.md to refresh the local dev environment.',
+      'If your local BakeMate database was recreated, repopulate it using your usual local seed path before reloading /ops.',
+      'Reload /ops after the local dev database is refreshed.',
+    ],
+  };
+}
+
+export default function OpsHome() {
+  const [orders, setOrders] = useState<OrderRecord[]>([]);
+  const [summary, setSummary] = useState<DayRunningQueueSummary | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [readinessState, setReadinessState] = useState<OpsHomeReadinessState | null>(null);
+  const [retryFeedback, setRetryFeedback] = useState<OpsHomeRetryFeedback | null>(null);
+  const [isRetryingReadiness, setIsRetryingReadiness] = useState(false);
+
+  const loadOpsHome = useCallback(async (options?: { fromRetry?: boolean }) => {
+    setIsLoading(true);
+    setError(null);
+    setReadinessState(null);
+    if (options?.fromRetry) {
+      setIsRetryingReadiness(true);
+      setRetryFeedback(null);
+    } else {
+      setRetryFeedback(null);
+    }
+    try {
+      const params = {
+        day_running: undefined,
+        action_class: undefined,
+        urgency: undefined,
+      };
+      const [ordersData, summaryData] = await Promise.all([
+        ordersApi.list(params),
+        ordersApi.getDayRunningSummary(params),
+      ]);
+      setOrders(ordersData);
+      setSummary(summaryData);
+      if (options?.fromRetry) {
+        setRetryFeedback(getGuardedOpsRetryFeedback('recovered'));
+      } else {
+        setRetryFeedback(null);
+      }
+    } catch (loadError) {
+      const nextReadinessState = getReadinessState(loadError);
+      if (nextReadinessState) {
+        setReadinessState(nextReadinessState);
+        setOrders([]);
+        setSummary(null);
+        if (options?.fromRetry) {
+          setRetryFeedback(getGuardedOpsRetryFeedback('still_stale'));
+        }
+        return;
+      }
+      setRetryFeedback(null);
+      setError('Unable to load Ops Home preview.');
+    } finally {
+      setIsLoading(false);
+      setIsRetryingReadiness(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadOpsHome();
+  }, [loadOpsHome]);
+
+  const retryUiState = useMemo(
+    () => getGuardedOpsRetryUiState(isRetryingReadiness),
+    [isRetryingReadiness],
+  );
+  const topOrders = useMemo(() => getTopAttentionOrders(orders), [orders]);
+  const blockedOrders = useMemo(
+    () => topOrders.filter((order) => order.day_running_focus_summary.readiness_label === 'Blocked for today').slice(0, 3),
+    [topOrders],
+  );
+  const attentionOrders = useMemo(
+    () => topOrders.filter((order) => order.day_running_focus_summary.readiness_label === 'Needs attention today').slice(0, 3),
+    [topOrders],
+  );
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-2xl bg-white p-6 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Preview</div>
+            <h1 className="mt-2 text-3xl font-bold text-slate-900">Ops Home</h1>
+            <p className="mt-2 max-w-3xl text-sm text-slate-600">
+              A visible front door for BakeMate’s trusted day-running view. This preview reuses the same
+              backend queue, readiness, and imported-payment trust signals already accepted in the order
+              surfaces.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              className="inline-flex items-center rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+              to="/orders"
+            >
+              Full queue
+            </Link>
+            <Link
+              className="inline-flex items-center rounded-lg bg-slate-900 px-3 py-2 text-sm font-semibold text-white hover:bg-slate-700"
+              to="/orders/imported"
+            >
+              Imported review
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-4">
+        {[
+          { key: 'all' as const, label: 'Visible day-running work' },
+          { key: 'blocked' as const, label: 'Blocked for today' },
+          { key: 'needs_attention' as const, label: 'Needs attention' },
+          { key: 'ready' as const, label: 'Ready now' },
+        ].map((card) => (
+          <article
+            key={card.key}
+            className={`rounded-2xl border p-4 shadow-sm ${getSummaryCardTone(card.key)}`}
+          >
+            <div className="text-xs font-semibold uppercase tracking-wide">{card.label}</div>
+            <div className="mt-3 text-3xl font-bold text-slate-900">
+              {readinessState ? '—' : getDayRunningCount(summary, card.key)}
+            </div>
+          </article>
+        ))}
+      </section>
+
+      {readinessState ? (
+        <section className="rounded-2xl border border-amber-200 bg-amber-50 p-6 shadow-sm">
+          <div className="max-w-3xl">
+            <div className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-700">Local dev readiness</div>
+            <h2 className="mt-2 text-2xl font-bold text-slate-900">{readinessState.title}</h2>
+            <p className="mt-3 text-sm text-slate-700">{readinessState.message}</p>
+            <p className="mt-2 text-sm text-slate-600">{readinessState.note}</p>
+            <div className="mt-4 rounded-xl border border-amber-300 bg-white px-4 py-3 text-sm text-slate-700">
+              <span className="font-semibold text-slate-900">Next step:</span> {readinessState.action}
+            </div>
+            <div className="mt-4 rounded-xl border border-slate-200 bg-white px-4 py-4 text-sm text-slate-700">
+              <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                {readinessState.guidanceTitle}
+              </div>
+              <div className="mt-3 rounded-lg border border-slate-200 bg-slate-950 px-3 py-3">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-300">
+                  {readinessState.recoveryCommandLabel}
+                </div>
+                <code className="mt-2 block overflow-x-auto whitespace-pre-wrap break-all font-mono text-sm text-slate-100">
+                  {readinessState.recoveryCommand}
+                </code>
+              </div>
+              <ul className="mt-3 list-disc space-y-2 pl-5">
+                {readinessState.guidanceSteps.map((step) => (
+                  <li key={step}>{step}</li>
+                ))}
+              </ul>
+              <div className="mt-4 flex flex-wrap items-center gap-3">
+                <button
+                  className="inline-flex items-center rounded-lg border border-amber-300 bg-amber-100 px-3 py-2 text-sm font-semibold text-amber-900 transition-colors hover:bg-amber-200 disabled:cursor-not-allowed disabled:opacity-70"
+                  onClick={() => {
+                    if (isRetryingReadiness) {
+                      return;
+                    }
+                    void loadOpsHome({ fromRetry: true });
+                  }}
+                  disabled={retryUiState.disabled}
+                  type="button"
+                >
+                  {retryUiState.label}
+                </button>
+                <span className="text-xs text-slate-500">
+                  {retryUiState.helperText}
+                </span>
+              </div>
+              {retryFeedback && retryFeedback.tone === 'warning' ? (
+                <div className="mt-3 rounded-xl border border-amber-200 bg-amber-100/70 px-4 py-3 text-sm text-amber-900">
+                  <span className="font-semibold">{retryFeedback.checkedLabel}:</span> {retryFeedback.message}
+                </div>
+              ) : null}
+              <div className="mt-3 text-xs text-slate-500">
+                Canonical local setup guide: {readinessState.guidanceSource}
+              </div>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {retryFeedback && !readinessState && retryFeedback.tone === 'success' ? (
+        <section className="rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-4 shadow-sm">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="text-sm text-emerald-900">
+              <span className="font-semibold">{retryFeedback.checkedLabel}:</span> {retryFeedback.message}
+            </div>
+            <button
+              className="inline-flex items-center rounded-lg border border-emerald-300 bg-white px-3 py-1.5 text-sm font-semibold text-emerald-900 transition-colors hover:bg-emerald-100"
+              onClick={() => {
+                setRetryFeedback((currentFeedback) => dismissGuardedOpsRetryFeedback(currentFeedback));
+              }}
+              type="button"
+            >
+              {retryFeedback.dismissLabel ?? 'Dismiss'}
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,1.6fr),minmax(320px,0.9fr)]">
+        <section className="rounded-2xl bg-white p-6 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-900">What needs attention now</h2>
+              <p className="mt-1 text-sm text-slate-600">{getAttentionHeadline(summary)}</p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="rounded-xl bg-slate-100 px-4 py-3 text-right">
+                <div className="text-xs uppercase tracking-wide text-slate-500">Queue preview</div>
+                <div className="text-2xl font-semibold text-slate-900">{topOrders.length}</div>
+                <div className="mt-1 text-xs font-semibold text-slate-600">{getOpsQueuePreviewPriorityLabel()}</div>
+                <div className="mt-1 text-xs text-slate-500">{getOpsQueuePreviewScopeLabel(topOrders.length)}</div>
+                <div className="mt-1 text-xs text-slate-500">{getOpsQueuePreviewDrillInAffordanceLabel()}</div>
+              </div>
+              <Link
+                className="inline-flex items-center rounded-lg border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50"
+                to="/orders"
+              >
+                View full queue
+              </Link>
+            </div>
+          </div>
+
+          {isLoading ? <p className="mt-4 text-sm text-slate-600">Loading ops preview...</p> : null}
+          {error ? <p className="mt-4 text-sm text-rose-600">{error}</p> : null}
+          {!isLoading && !error && topOrders.length === 0 ? (
+            <p className="mt-4 text-sm text-slate-600">No visible ops work is currently available.</p>
+          ) : null}
+
+          <div className="mt-6 space-y-4">
+            {topOrders.map((order) => {
+              const queueBadge = getQueueBadge(order);
+              const actionClassMeta = getActionClassMeta(order.ops_summary.action_class);
+              const dayRunningMeta = getDayRunningMeta(order.day_running_focus_summary.readiness_label);
+              const rowPriorityCue = getOpsQueuePreviewRowPriorityCue(order.queue_summary.urgency_label);
+              const rowReasonCue = getOpsQueuePreviewRowReasonCue(
+                order.day_running_focus_summary.readiness_label,
+                order.day_running_focus_summary.queue_reason_preview,
+              );
+              const rowNextStepCue = getOpsQueuePreviewRowNextStepCue(
+                order.day_running_focus_summary.readiness_label,
+                order.day_running_focus_summary.queue_next_step_preview,
+              );
+
+              return (
+                <article key={order.id} className="rounded-2xl border border-slate-200 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2 text-sm font-semibold text-slate-900">
+                        {order.order_number}
+                        <span className="text-slate-400">•</span>
+                        <span>{order.customer_summary.name || order.customer_summary.email || 'No customer'}</span>
+                        <span className={`rounded-full px-2 py-1 text-xs font-semibold ${queueBadge.className}`}>
+                          {queueBadge.label}
+                        </span>
+                        <span
+                          className={`rounded-full px-2 py-1 text-xs font-semibold ${actionClassMeta.className}`}
+                        >
+                          {actionClassMeta.label}
+                        </span>
+                      </div>
+                      <div className="mt-1 text-sm text-slate-600">
+                        Due {formatBakeryDateTime(order.due_date)} • {order.delivery_method || 'delivery TBD'}
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <div className="text-sm font-semibold text-slate-900">{formatMoney(order.total_amount)}</div>
+                      <div className="mt-1 text-xs uppercase tracking-wide text-slate-500">
+                        {humanizeStatus(order.payment_status)}
+                      </div>
+                      <div className="mt-2 flex flex-col items-end gap-2">
+                        <span
+                          className={`inline-flex rounded-full border px-2.5 py-1 text-[11px] font-semibold ${rowPriorityCue.className}`}
+                        >
+                          {rowPriorityCue.label}
+                        </span>
+                        {rowReasonCue ? <div className="text-xs font-medium text-slate-600">{rowReasonCue}</div> : null}
+                        {rowNextStepCue ? <div className="text-xs font-medium text-slate-600">{rowNextStepCue}</div> : null}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className={`mt-4 rounded-xl border p-4 ${dayRunningMeta}`}>
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <div className="text-xs uppercase tracking-wide">Day-running readiness</div>
+                        <div className="mt-1 text-sm font-semibold text-slate-900">
+                          {order.day_running_focus_summary.readiness_label}
+                        </div>
+                        <div className="mt-1 text-sm text-slate-700">
+                          {order.day_running_focus_summary.queue_reason_preview ??
+                            order.day_running_focus_summary.reason_summary}
+                        </div>
+                        {order.day_running_focus_summary.queue_payment_trust_preview ? (
+                          <div className="mt-2 text-xs font-medium text-sky-700">
+                            {order.day_running_focus_summary.queue_payment_trust_preview}
+                          </div>
+                        ) : null}
+                      </div>
+                      <div className="text-right text-xs text-slate-600 max-w-[220px]">
+                        {order.day_running_focus_summary.primary_blocker_label}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4">
+                    <div>
+                      <div className="text-xs uppercase tracking-wide text-amber-700">Next action</div>
+                      <div className="mt-1 text-base font-semibold text-slate-900">{order.ops_summary.next_action}</div>
+                      <div className="mt-1 text-sm text-slate-700">{order.ops_summary.ops_attention}</div>
+                    </div>
+                    <Link
+                      className={`inline-flex rounded-lg px-3 py-2 text-sm font-semibold transition-colors ${actionClassMeta.ctaClassName}`}
+                      to={order.ops_summary.primary_cta_path}
+                    >
+                      {order.ops_summary.primary_cta_label}
+                    </Link>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <aside className="space-y-6">
+          <section className="rounded-2xl bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-slate-900">Ops readout</h2>
+            <div className="mt-4 space-y-3 text-sm text-slate-700">
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Blocked first</div>
+                <div className="mt-2 text-sm text-slate-900">
+                  {blockedOrders.length > 0
+                    ? blockedOrders.map((order) => order.order_number).join(', ')
+                    : 'No blocked orders in the current queue preview.'}
+                </div>
+              </div>
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Attention next</div>
+                <div className="mt-2 text-sm text-slate-900">
+                  {attentionOrders.length > 0
+                    ? attentionOrders.map((order) => order.order_number).join(', ')
+                    : 'No needs-attention orders in the current queue preview.'}
+                </div>
+              </div>
+              <div className="rounded-xl border border-sky-200 bg-sky-50 p-4">
+                <div className="text-xs font-semibold uppercase tracking-wide text-sky-700">Imported payment trust</div>
+                <div className="mt-2 text-sm text-slate-900">
+                  Imported orders keep the accepted payment trust boundary visible here as
+                  <span className="font-semibold"> Payment trust: legacy-limited</span>.
+                </div>
+                <div className="mt-2 text-xs text-slate-600">
+                  This preview stays informational only. It does not invent stronger historical payment certainty.
+                </div>
+              </div>
+            </div>
+          </section>
+        </aside>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/OrderDetail.tsx
+++ b/frontend/src/pages/OrderDetail.tsx
@@ -317,6 +317,13 @@ export default function OrderDetail() {
                       <div className="mt-3 text-sm text-slate-700">{order.contact_focus_summary.attention_note}</div>
                     </div>
 
+                    {order.review_focus_summary.payment_trust_preview ? (
+                      <div className="rounded-xl border border-sky-200 bg-sky-50 p-4">
+                        <div className="text-xs font-semibold uppercase tracking-wide text-sky-700">Payment trust</div>
+                        <div className="mt-2 text-sm text-slate-900">{order.review_focus_summary.payment_trust_preview}</div>
+                      </div>
+                    ) : null}
+
                     <div className="grid gap-4 md:grid-cols-3">
                       <div className="rounded-xl border border-slate-200 p-4">
                         <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Payment confidence</div>
@@ -478,6 +485,25 @@ export default function OrderDetail() {
 
                 <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1.2fr),minmax(0,0.8fr)]">
                   <div className="space-y-4">
+                    <div className={`rounded-xl border p-4 ${order.payment_focus_summary.trust_state === 'legacy_limited' ? 'border-sky-200 bg-sky-50' : 'border-emerald-200 bg-emerald-50'}`}>
+                      <div className={`text-xs font-semibold uppercase tracking-wide ${order.payment_focus_summary.trust_state === 'legacy_limited' ? 'text-sky-700' : 'text-emerald-700'}`}>
+                        Payment trust boundary
+                      </div>
+                      <div className="mt-2 text-sm font-semibold text-slate-900">{order.payment_focus_summary.trust_label}</div>
+                      <div className="mt-1 text-sm text-slate-700">{order.payment_focus_summary.trust_note}</div>
+                    </div>
+
+                    {order.payment_focus_summary.historical_payment_label ? (
+                      <div className="rounded-xl border border-sky-200 bg-sky-50 p-4">
+                        <div className="text-xs font-semibold uppercase tracking-wide text-sky-700">
+                          {order.payment_focus_summary.historical_payment_label}
+                        </div>
+                        <div className="mt-2 text-sm text-slate-900">
+                          {order.payment_focus_summary.historical_payment_note}
+                        </div>
+                      </div>
+                    ) : null}
+
                     <div className="rounded-2xl border border-rose-100 bg-rose-50 p-4">
                       <div className="text-xs font-semibold uppercase tracking-wide text-rose-700">Amount owed now</div>
                       <div className="mt-2 text-3xl font-bold text-slate-900">

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -582,6 +582,11 @@ export default function Orders() {
                                   ) : null}
                                 </>
                               ) : null}
+                              {order.day_running_focus_summary.queue_payment_trust_preview ? (
+                                <div className="mt-2 text-xs font-medium text-sky-700">
+                                  {order.day_running_focus_summary.queue_payment_trust_preview}
+                                </div>
+                              ) : null}
                             </div>
                             <div className="text-right text-xs text-slate-600 max-w-[220px]">
                               {order.day_running_focus_summary.primary_blocker_label}

--- a/frontend/src/pages/opsHomeRetryState.test.ts
+++ b/frontend/src/pages/opsHomeRetryState.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  dismissGuardedOpsRetryFeedback,
+  getGuardedOpsRetryFeedback,
+  getGuardedOpsRetryUiState,
+} from './opsHomeRetryState.ts';
+
+test('guarded ops retry UI stays idle until a guarded retry is active', () => {
+  assert.deepEqual(getGuardedOpsRetryUiState(false), {
+    label: 'Try /ops again',
+    disabled: false,
+    helperText: 'After you run the local recovery command above, re-check the normal /ops view here.',
+  });
+});
+
+test('guarded ops retry UI shows compact checking state while retry is in flight', () => {
+  assert.deepEqual(getGuardedOpsRetryUiState(true), {
+    label: 'Checking /ops...',
+    disabled: true,
+    helperText: 'BakeMate is re-checking the normal local /ops view now.',
+  });
+});
+
+test('guarded ops retry feedback stays warning-scoped when local dev is still stale', () => {
+  assert.deepEqual(getGuardedOpsRetryFeedback('still_stale'), {
+    tone: 'warning',
+    checkedLabel: 'Checked just now',
+    message: 'Local dev setup is still not ready. Verify the local recovery steps above, then try /ops again.',
+  });
+});
+
+test('guarded ops retry feedback shows compact success confirmation only on recovery', () => {
+  assert.deepEqual(getGuardedOpsRetryFeedback('recovered'), {
+    tone: 'success',
+    checkedLabel: 'Recovered just now',
+    message: 'Local dev setup is ready again. Showing the normal /ops view now.',
+    dismissLabel: 'Dismiss',
+  });
+});
+
+test('guarded ops retry success feedback can be dismissed back to the clean healthy state', () => {
+  assert.equal(dismissGuardedOpsRetryFeedback(getGuardedOpsRetryFeedback('recovered')), null);
+});
+
+test('guarded ops retry warning feedback does not get cleared by success dismiss handling', () => {
+  const warningFeedback = getGuardedOpsRetryFeedback('still_stale');
+  assert.deepEqual(dismissGuardedOpsRetryFeedback(warningFeedback), warningFeedback);
+});

--- a/frontend/src/pages/opsHomeRetryState.ts
+++ b/frontend/src/pages/opsHomeRetryState.ts
@@ -1,0 +1,55 @@
+export type GuardedOpsRetryUiState = {
+  label: string;
+  disabled: boolean;
+  helperText: string;
+};
+
+export type GuardedOpsRetryFeedback = {
+  tone: 'warning' | 'success';
+  checkedLabel: string;
+  message: string;
+  dismissLabel?: string;
+};
+
+export function getGuardedOpsRetryUiState(isRetrying: boolean): GuardedOpsRetryUiState {
+  if (isRetrying) {
+    return {
+      label: 'Checking /ops...',
+      disabled: true,
+      helperText: 'BakeMate is re-checking the normal local /ops view now.',
+    };
+  }
+
+  return {
+    label: 'Try /ops again',
+    disabled: false,
+    helperText: 'After you run the local recovery command above, re-check the normal /ops view here.',
+  };
+}
+
+export function getGuardedOpsRetryFeedback(outcome: 'still_stale' | 'recovered'): GuardedOpsRetryFeedback {
+  if (outcome === 'recovered') {
+    return {
+      tone: 'success',
+      checkedLabel: 'Recovered just now',
+      message: 'Local dev setup is ready again. Showing the normal /ops view now.',
+      dismissLabel: 'Dismiss',
+    };
+  }
+
+  return {
+    tone: 'warning',
+    checkedLabel: 'Checked just now',
+    message: 'Local dev setup is still not ready. Verify the local recovery steps above, then try /ops again.',
+  };
+}
+
+export function dismissGuardedOpsRetryFeedback(
+  feedback: GuardedOpsRetryFeedback | null,
+): GuardedOpsRetryFeedback | null {
+  if (!feedback || feedback.tone !== 'success') {
+    return feedback;
+  }
+
+  return null;
+}

--- a/frontend/src/pages/opsQueuePreviewDrillInAffordance.test.ts
+++ b/frontend/src/pages/opsQueuePreviewDrillInAffordance.test.ts
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getOpsQueuePreviewDrillInAffordanceLabel } from './opsQueuePreviewDrillInAffordance.ts';
+
+test('ops queue preview drill-in affordance makes order-detail opening explicit', () => {
+  assert.equal(getOpsQueuePreviewDrillInAffordanceLabel(), 'Open any order for details.');
+});

--- a/frontend/src/pages/opsQueuePreviewDrillInAffordance.ts
+++ b/frontend/src/pages/opsQueuePreviewDrillInAffordance.ts
@@ -1,0 +1,3 @@
+export function getOpsQueuePreviewDrillInAffordanceLabel() {
+  return 'Open any order for details.';
+}

--- a/frontend/src/pages/opsQueuePreviewPriority.test.ts
+++ b/frontend/src/pages/opsQueuePreviewPriority.test.ts
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getOpsQueuePreviewPriorityLabel } from './opsQueuePreviewPriority.ts';
+
+test('ops queue preview priority label explains that healthy ops shows the top work first', () => {
+  assert.equal(getOpsQueuePreviewPriorityLabel(), 'Highest-priority orders first.');
+});

--- a/frontend/src/pages/opsQueuePreviewPriority.ts
+++ b/frontend/src/pages/opsQueuePreviewPriority.ts
@@ -1,0 +1,3 @@
+export function getOpsQueuePreviewPriorityLabel() {
+  return 'Highest-priority orders first.';
+}

--- a/frontend/src/pages/opsQueuePreviewRowNextStepCue.test.ts
+++ b/frontend/src/pages/opsQueuePreviewRowNextStepCue.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getOpsQueuePreviewRowNextStepCue } from './opsQueuePreviewRowNextStepCue.ts';
+
+test('ops queue preview row next-step cue reuses trusted queue next-step meaning for blocked work', () => {
+  assert.equal(
+    getOpsQueuePreviewRowNextStepCue('Blocked for today', 'Next: finish invoice'),
+    'Next: finish invoice',
+  );
+});
+
+test('ops queue preview row next-step cue reuses trusted queue next-step meaning for attention work', () => {
+  assert.equal(
+    getOpsQueuePreviewRowNextStepCue('Needs attention today', 'Next: collect deposit'),
+    'Next: collect deposit',
+  );
+});
+
+test('ops queue preview row next-step cue stays quiet for ready work', () => {
+  assert.equal(getOpsQueuePreviewRowNextStepCue('Ready for today', 'Next: review order'), null);
+});
+
+test('ops queue preview row next-step cue stays quiet when trusted queue guidance is absent', () => {
+  assert.equal(getOpsQueuePreviewRowNextStepCue('Blocked for today', null), null);
+});

--- a/frontend/src/pages/opsQueuePreviewRowNextStepCue.ts
+++ b/frontend/src/pages/opsQueuePreviewRowNextStepCue.ts
@@ -1,0 +1,10 @@
+export function getOpsQueuePreviewRowNextStepCue(
+  readinessLabel: string,
+  queueNextStepPreview?: string | null,
+): string | null {
+  if (readinessLabel === 'Ready for today') {
+    return null;
+  }
+
+  return queueNextStepPreview ?? null;
+}

--- a/frontend/src/pages/opsQueuePreviewRowPriorityCue.test.ts
+++ b/frontend/src/pages/opsQueuePreviewRowPriorityCue.test.ts
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getOpsQueuePreviewRowPriorityCue } from './opsQueuePreviewRowPriorityCue.ts';
+
+test('ops queue preview row priority cue reuses urgent queue meaning', () => {
+  assert.deepEqual(getOpsQueuePreviewRowPriorityCue('Urgent'), {
+    label: 'Priority: Urgent',
+    className: 'border-rose-200 bg-rose-50 text-rose-700',
+  });
+});
+
+test('ops queue preview row priority cue reuses today queue meaning', () => {
+  assert.deepEqual(getOpsQueuePreviewRowPriorityCue('Today'), {
+    label: 'Priority: Today',
+    className: 'border-amber-200 bg-amber-50 text-amber-800',
+  });
+});
+
+test('ops queue preview row priority cue reuses next-up queue meaning', () => {
+  assert.deepEqual(getOpsQueuePreviewRowPriorityCue('Next up'), {
+    label: 'Priority: Next up',
+    className: 'border-sky-200 bg-sky-50 text-sky-800',
+  });
+});
+
+test('ops queue preview row priority cue stays compact for watch-level work', () => {
+  assert.deepEqual(getOpsQueuePreviewRowPriorityCue('Watch'), {
+    label: 'Priority: Watch',
+    className: 'border-slate-200 bg-slate-50 text-slate-700',
+  });
+});

--- a/frontend/src/pages/opsQueuePreviewRowPriorityCue.ts
+++ b/frontend/src/pages/opsQueuePreviewRowPriorityCue.ts
@@ -1,0 +1,29 @@
+type OpsQueuePreviewRowPriorityCue = {
+  label: string;
+  className: string;
+};
+
+export function getOpsQueuePreviewRowPriorityCue(urgencyLabel: string): OpsQueuePreviewRowPriorityCue {
+  switch (urgencyLabel) {
+    case 'Urgent':
+      return {
+        label: 'Priority: Urgent',
+        className: 'border-rose-200 bg-rose-50 text-rose-700',
+      };
+    case 'Today':
+      return {
+        label: 'Priority: Today',
+        className: 'border-amber-200 bg-amber-50 text-amber-800',
+      };
+    case 'Next up':
+      return {
+        label: 'Priority: Next up',
+        className: 'border-sky-200 bg-sky-50 text-sky-800',
+      };
+    default:
+      return {
+        label: `Priority: ${urgencyLabel}`,
+        className: 'border-slate-200 bg-slate-50 text-slate-700',
+      };
+  }
+}

--- a/frontend/src/pages/opsQueuePreviewRowReasonCue.test.ts
+++ b/frontend/src/pages/opsQueuePreviewRowReasonCue.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getOpsQueuePreviewRowReasonCue } from './opsQueuePreviewRowReasonCue.ts';
+
+test('ops queue preview row reason cue reuses trusted queue reason meaning for blocked work', () => {
+  assert.equal(
+    getOpsQueuePreviewRowReasonCue('Blocked for today', 'Attention: Invoice basics missing'),
+    'Attention: Invoice basics missing',
+  );
+});
+
+test('ops queue preview row reason cue reuses trusted queue reason meaning for attention work', () => {
+  assert.equal(
+    getOpsQueuePreviewRowReasonCue('Needs attention today', 'Attention: Deposit due'),
+    'Attention: Deposit due',
+  );
+});
+
+test('ops queue preview row reason cue stays quiet for ready work', () => {
+  assert.equal(getOpsQueuePreviewRowReasonCue('Ready for today', 'Attention: Review order'), null);
+});
+
+test('ops queue preview row reason cue stays quiet when trusted queue guidance is absent', () => {
+  assert.equal(getOpsQueuePreviewRowReasonCue('Blocked for today', null), null);
+});

--- a/frontend/src/pages/opsQueuePreviewRowReasonCue.ts
+++ b/frontend/src/pages/opsQueuePreviewRowReasonCue.ts
@@ -1,0 +1,10 @@
+export function getOpsQueuePreviewRowReasonCue(
+  readinessLabel: string,
+  queueReasonPreview?: string | null,
+): string | null {
+  if (readinessLabel === 'Ready for today') {
+    return null;
+  }
+
+  return queueReasonPreview ?? null;
+}

--- a/frontend/src/pages/opsQueuePreviewScope.test.ts
+++ b/frontend/src/pages/opsQueuePreviewScope.test.ts
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getOpsQueuePreviewScopeLabel } from './opsQueuePreviewScope.ts';
+
+test('ops queue preview scope label makes singular preview scope explicit', () => {
+  assert.equal(getOpsQueuePreviewScopeLabel(1), 'Showing 1 preview item of the full queue.');
+});
+
+test('ops queue preview scope label makes plural preview scope explicit', () => {
+  assert.equal(getOpsQueuePreviewScopeLabel(5), 'Showing 5 preview items of the full queue.');
+});
+
+test('ops queue preview scope label stays explicit even when no preview rows are visible', () => {
+  assert.equal(getOpsQueuePreviewScopeLabel(0), 'Showing 0 preview items of the full queue.');
+});

--- a/frontend/src/pages/opsQueuePreviewScope.ts
+++ b/frontend/src/pages/opsQueuePreviewScope.ts
@@ -1,0 +1,7 @@
+export function getOpsQueuePreviewScopeLabel(previewItemCount: number) {
+  if (previewItemCount === 1) {
+    return 'Showing 1 preview item of the full queue.';
+  }
+
+  return `Showing ${previewItemCount} preview items of the full queue.`;
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -23,5 +23,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8001',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- Adds Next.js frontend scaffolding (`frontend-next/`) with order detail parity surfaces: orders queue, order detail entry, ops shell proof, login, auth
- Lands BM-093 preview front door: ops preview, preview validation, review/handoff/invoice/payment panels with tests
- Commits accepted preview validation follow-through: seed preview data, backend config updates, preview validation test

## Changes (3 commits, 45 files, ~3.6k lines)
- **frontend-next**: Full Next.js app with pages (orders, order detail, ops, login), components, lib helpers, and test suite
- **backend**: Seed data expansion for preview validation, config updates, unit test additions
- **Tests**: auth-compat, handoff-panel, imported-review-panel, invoice-panel, ops-preview, order-detail-entry, orders-queue, payment-panel, preview-validation, review-panel

## Test plan
- [ ] `cd frontend-next && npm test` — frontend test suite
- [ ] `cd backend && pytest tests/unit/test_seed_preview_validation.py` — preview validation seed test
- [ ] `cd backend && pytest tests/unit/test_orders_bm006_service.py` — orders service test
- [ ] Review preview flow end-to-end via `npm run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)